### PR TITLE
fix(notification): don't try to send SMS on develop

### DIFF
--- a/src/features/notification/service.ts
+++ b/src/features/notification/service.ts
@@ -97,6 +97,18 @@ export async function sendSMS(
   message: string,
   convertUnicode?: boolean
 ) {
+  if (process.env.NODE_ENV !== 'production') {
+    logger.info(
+      `Tried to send SMS notification. Ignoring due to NODE_ENV not being 'production'. Params:`,
+      {
+        msisdn,
+        message,
+        convertUnicode
+      }
+    )
+    return
+  }
+
   switch (SMS_PROVIDER) {
     case 'clickatell':
       return sendSMSClickatell(msisdn, message, convertUnicode)


### PR DESCRIPTION
This sometimes appears in my console and I don't think it's relevant on development:
```
{"level":50,"time":1681716999009,"pid":2749,"hostname":"DESKTOP-4TD8SBI","msg":"Only absolute URLs are supported","stack":"TypeError: Only absolute URLs are supported\n    at getNodeRequestOptions (/root/Projects/opencrvs-farajaland/node_modules/node-fetch/lib/index.js:1327:9)\n    at /root/Projects/opencrvs-farajaland/node_modules/node-fetch/lib/index.js:1440:19\n    at new Promise (<anonymous>)\n    at fetch (/root/Projects/opencrvs-farajaland/node_modules/node-fetch/lib/index.js:1437:9)\n    at /root/Projects/opencrvs-farajaland/src/features/notification/service.ts:77:27\n    at Generator.next (<anonymous>)\n    at /root/Projects/opencrvs-farajaland/src/features/notification/service.ts:8:71\n    at new Promise (<anonymous>)\n    at __awaiter (/root/Projects/opencrvs-farajaland/src/features/notification/service.ts:4:12)\n    at sendSMSInfobip (/root/Projects/opencrvs-farajaland/src/features/notification/service.ts:52:12)\n    at /root/Projects/opencrvs-farajaland/src/features/notification/service.ts:104:14\n    at Generator.next (<anonymous>)\n    at /root/Projects/opencrvs-farajaland/src/features/notification/service.ts:8:71\n    at new Promise (<anonymous>)\n    at __awaiter (/root/Projects/opencrvs-farajaland/src/features/notification/service.ts:4:12)\n    at sendSMS (/root/Projects/opencrvs-farajaland/src/features/notification/service.ts:92:12)","type":"Error","v":1}
Debug: internal, implementation, error 
    TypeError: Only absolute URLs are supported
    at getNodeRequestOptions (/root/Projects/opencrvs-farajaland/node_modules/node-fetch/lib/index.js:1327:9)
    at /root/Projects/opencrvs-farajaland/node_modules/node-fetch/lib/index.js:1440:19
    at new Promise (<anonymous>)
    at fetch (/root/Projects/opencrvs-farajaland/node_modules/node-fetch/lib/index.js:1437:9)
    at /root/Projects/opencrvs-farajaland/src/features/notification/service.ts:77:27
    at Generator.next (<anonymous>)
    at /root/Projects/opencrvs-farajaland/src/features/notification/service.ts:8:71
    at new Promise (<anonymous>)
    at __awaiter (/root/Projects/opencrvs-farajaland/src/features/notification/service.ts:4:12)
    at sendSMSInfobip (/root/Projects/opencrvs-farajaland/src/features/notification/service.ts:52:12)
    at /root/Projects/opencrvs-farajaland/src/features/notification/service.ts:104:14
    at Generator.next (<anonymous>)
    at /root/Projects/opencrvs-farajaland/src/features/notification/service.ts:8:71
    at new Promise (<anonymous>)
    at __awaiter (/root/Projects/opencrvs-farajaland/src/features/notification/service.ts:4:12)
    at sendSMS (/root/Projects/opencrvs-farajaland/src/features/notification/service.ts:92:12
```