### PR TITLE
fix: error in the farajaland birth certificate svg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ INSERT CSV ROWS IN ENGLISH ONLY
 
 - TBC
 
+## 1.6.1 Release candidate
+
+### Bug fixes
+
+- Fix a typo in the birth certificate svg code that was causing the birth certificate to fail to render in the `print certified copy` flow. [7886](https://github.com/opencrvs/opencrvs-core/issues/7886)
+
 ## 1.6.0 Release candidate
 
 ### Breaking changes

--- a/src/api/certificates/source/Farajaland-birth-certificate-v2.svg
+++ b/src/api/certificates/source/Farajaland-birth-certificate-v2.svg
@@ -29,7 +29,6 @@
 <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px"><tspan x="80.9999" y="701.112">{{location loggedInUser.officeId 'name'}}&#x2028;</tspan><tspan x="80.9999" y="713.912">{{location loggedInUser.districtId 'name'}}, {{location loggedInUser.stateId 'name'}}, Farajaland</tspan></text>
 <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px"><tspan x="234.391" y="688.312">&#x2028;</tspan></text>
 <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" font-weight="bold" letter-spacing="0px"><tspan x="80.9999" y="688.312">Place of certification / Lieu de d&#xe9;livrance</tspan></text>
-</text>
 
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" font-weight="bold" letter-spacing="0px">
         <tspan x="80.9999" y="735.444">&#10;</tspan>


### PR DESCRIPTION
There was an extra </text> missed from a previous refactor, so deleting it fixes the svg parsing error that we were seeing the the print certified copy review screen

Addresses https://github.com/opencrvs/opencrvs-core/issues/7886