### PR TITLE
Fixed the tag for alpine image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Ensure that place of birth/death only shows active facilities/offices on the form [#9311](https://github.com/opencrvs/opencrvs-core/issues/9311)
 
+### Improvements
+
+- Use the Alpine image with the fixed tag `3.22.1` during the backup process
+
 ## 1.8.0
 
 ### New features

--- a/infrastructure/backups/backup.sh
+++ b/infrastructure/backups/backup.sh
@@ -216,7 +216,7 @@ echo "Creating a backup for SQLite"
 docker run --rm \
   -v $ROOT_PATH/sqlite:/data/sqlite \
   -v $ROOT_PATH/backups/sqlite:/data/backup \
-  alpine sh -c "apk add --no-cache sqlite && \
+  alpine:3.22.1 sh -c "apk add --no-cache sqlite && \
   sqlite3 /data/sqlite/mosip-api.db \".backup '/data/backup/mosip-api-${LABEL:-$BACKUP_DATE}.sqlite'\""
 
 #-------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Despite of latest we are now opt to use a fixed tag for alpine image
It will prevent appearing unnecessary logs to our `opencrvs-backup.error.log` file

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
