### PR TITLE
chore: remove global timeout

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig, devices } from '@playwright/test'
 
-const TEST_TIMEOUT = 90000
-
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -12,7 +10,6 @@ const TEST_TIMEOUT = 90000
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  timeout: TEST_TIMEOUT,
   testDir: './e2e/testcases',
   /* Run tests in files in parallel */
   fullyParallel: true,


### PR DESCRIPTION

## Description

We have retry mechanism for files. It seems that the file retry is the one that helps the tests pass in CI. Having both increases the runtime by a good margin. In failure situations, tests that are not gonna pass are left hanging.

The aim is to identify the tests that actually need minute and a half of retry. In those scenarios, we either change the tests, or if that is not possible identify the proper timeout https://playwright.dev/docs/test-timeouts



## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
