### PR TITLE
chore: remove worker limitation in tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,8 +20,6 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Don't retry */
   retries: process.env.CI ? 3 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['html', { open: 'never' }],


### PR DESCRIPTION
## Description
We have configured both fullyParallel and workers 1. It might be unintentional. Run tests to discover if it affects performance 

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
