### PR TITLE
chore: check first positive cases. Streamline assert workqueue

### DIFF
--- a/e2e/testcases/v2-application/1-my-draft.spec.ts
+++ b/e2e/testcases/v2-application/1-my-draft.spec.ts
@@ -5,6 +5,7 @@ import { CREDENTIALS } from '../../constants'
 import { faker } from '@faker-js/faker'
 import { getRowByTitle } from '../v2-print-certificate/birth/helpers'
 import { ensureOutboxIsEmpty } from '../../v2-utils'
+import { assertRecordInWorkqueue } from '../v2-birth/helpers'
 
 test.describe.serial('1: Validate my draft tab', () => {
   let page: Page
@@ -44,13 +45,16 @@ test.describe.serial('1: Validate my draft tab', () => {
   })
 
   test('1.3 Record appears in draft ', async () => {
-    await ensureOutboxIsEmpty(page)
-
-    await page.getByRole('button', { name: 'My drafts' }).click()
-
-    await expect(page.getByTestId('search-result')).toContainText(
-      formatName(name)
-    )
+    await assertRecordInWorkqueue({
+      page,
+      workqueues: [
+        {
+          title: 'My drafts',
+          exists: true
+        }
+      ],
+      name: formatName(name)
+    })
   })
 
   test('1.4 Record does not appear in draft for other user: RA ', async () => {
@@ -86,11 +90,15 @@ test.describe.serial('1: Validate my draft tab', () => {
     await page.getByRole('button', { name: 'Send for review' }).click()
     await page.getByRole('button', { name: 'Confirm' }).click()
 
-    await ensureOutboxIsEmpty(page)
-
-    await expect(page.getByTestId('search-result')).toContainText('My drafts')
-    await expect(page.getByTestId('search-result')).not.toContainText(
-      formatName(name)
-    )
+    await assertRecordInWorkqueue({
+      page,
+      workqueues: [
+        {
+          title: 'My drafts',
+          exists: false
+        }
+      ],
+      name: formatName(name)
+    })
   })
 })

--- a/e2e/testcases/v2-application/workqueue-flow-1.spec.ts
+++ b/e2e/testcases/v2-application/workqueue-flow-1.spec.ts
@@ -141,9 +141,9 @@ test.describe.serial('1. Workqueue flow - 1', () => {
         page,
         name: formatName(declaration.child.name),
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
           { title: 'Sent for review', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Requires updates', exists: false }
         ]
       })
@@ -158,9 +158,9 @@ test.describe.serial('1. Workqueue flow - 1', () => {
         page,
         name: formatName(declaration.child.name),
         workqueues: [
+          { title: 'Notifications', exists: true },
           { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: false },
-          { title: 'Notifications', exists: true },
           { title: 'Ready for review', exists: false },
           { title: 'Requires updates', exists: false },
           { title: 'Sent for approval', exists: false },
@@ -269,18 +269,16 @@ test.describe.serial('1. Workqueue flow - 1', () => {
       await page.getByRole('button', { name: 'Send for approval' }).click()
       await page.getByRole('button', { name: 'Confirm' }).click()
 
-      await ensureOutboxIsEmpty(page)
-
       await assertRecordInWorkqueue({
         page,
         name: formatName(declaration.child.name),
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
+          { title: 'Sent for approval', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Notifications', exists: false },
           { title: 'Ready for review', exists: false },
           { title: 'Requires updates', exists: false },
-          { title: 'Sent for approval', exists: true },
           { title: 'In external validation', exists: false },
           { title: 'Ready to print', exists: false }
         ]
@@ -311,10 +309,10 @@ test.describe.serial('1. Workqueue flow - 1', () => {
         page,
         name: formatName(declaration.child.name),
         workqueues: [
+          { title: 'Ready for review', exists: true },
           { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: false },
           { title: 'Notifications', exists: false },
-          { title: 'Ready for review', exists: true },
           { title: 'Requires updates', exists: false },
           { title: 'In external validation', exists: false },
           { title: 'Ready to print', exists: false }
@@ -338,19 +336,18 @@ test.describe.serial('1. Workqueue flow - 1', () => {
         })
         .click()
       await page.locator('#confirm_Register').click()
-      await ensureOutboxIsEmpty(page)
 
       await assertRecordInWorkqueue({
         page,
         name: formatName(declaration.child.name),
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
+          { title: 'Ready to print', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Notifications', exists: false },
           { title: 'Ready for review', exists: false },
           { title: 'Requires updates', exists: false },
-          { title: 'In external validation', exists: false },
-          { title: 'Ready to print', exists: true }
+          { title: 'In external validation', exists: false }
         ]
       })
     })
@@ -400,8 +397,8 @@ test.describe.serial('1. Workqueue flow - 1', () => {
       page,
       name: formatName(declaration.child.name),
       workqueues: [
-        { title: 'Assigned to you', exists: false },
         { title: 'Recent', exists: true },
+        { title: 'Assigned to you', exists: false },
         { title: 'Notifications', exists: false },
         { title: 'Ready for review', exists: false },
         { title: 'Requires updates', exists: false },

--- a/e2e/testcases/v2-application/workqueue-flow-2.spec.ts
+++ b/e2e/testcases/v2-application/workqueue-flow-2.spec.ts
@@ -136,9 +136,9 @@ test.describe.serial('2. Workqueue flow - 2', () => {
         page,
         name: formatName(declaration.child.name),
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
           { title: 'Sent for review', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Requires updates', exists: false }
         ]
       })
@@ -153,9 +153,9 @@ test.describe.serial('2. Workqueue flow - 2', () => {
         page,
         name: formatName(declaration.child.name),
         workqueues: [
+          { title: 'Notifications', exists: true },
           { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: false },
-          { title: 'Notifications', exists: true },
           { title: 'Ready for review', exists: false },
           { title: 'Requires updates', exists: false },
           { title: 'In external validation', exists: false },
@@ -263,19 +263,17 @@ test.describe.serial('2. Workqueue flow - 2', () => {
       await page.getByRole('button', { name: 'Register' }).click()
       await page.locator('#confirm_Declare').click()
 
-      await ensureOutboxIsEmpty(page)
-
       await assertRecordInWorkqueue({
         page,
         name: formatName(declaration.child.name),
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
+          { title: 'Ready to print', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Notifications', exists: false },
           { title: 'Ready for review', exists: false },
           { title: 'Requires updates', exists: false },
-          { title: 'In external validation', exists: false },
-          { title: 'Ready to print', exists: true }
+          { title: 'In external validation', exists: false }
         ]
       })
     })
@@ -303,14 +301,14 @@ test.describe.serial('2. Workqueue flow - 2', () => {
       page,
       name: formatName(declaration.child.name),
       workqueues: [
+        { title: 'Ready to print', exists: true },
         { title: 'Assigned to you', exists: false },
         { title: 'Recent', exists: false },
         { title: 'Notifications', exists: false },
         { title: 'Ready for review', exists: false },
         { title: 'Requires updates', exists: false },
         { title: 'Sent for approval', exists: false },
-        { title: 'In external validation', exists: false },
-        { title: 'Ready to print', exists: true }
+        { title: 'In external validation', exists: false }
       ]
     })
   })

--- a/e2e/testcases/v2-application/workqueue-flow-3.spec.ts
+++ b/e2e/testcases/v2-application/workqueue-flow-3.spec.ts
@@ -145,9 +145,9 @@ test.describe.serial('3. Workqueue flow - 3', () => {
         page,
         name: childName,
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
           { title: 'Sent for review', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Requires updates', exists: false }
         ]
       })
@@ -162,9 +162,9 @@ test.describe.serial('3. Workqueue flow - 3', () => {
         page,
         name: childName,
         workqueues: [
+          { title: 'Notifications', exists: true },
           { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: false },
-          { title: 'Notifications', exists: true },
           { title: 'Ready for review', exists: false },
           { title: 'Requires updates', exists: false },
           { title: 'Sent for approval', exists: false },
@@ -194,12 +194,12 @@ test.describe.serial('3. Workqueue flow - 3', () => {
         page,
         name: childName,
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
+          { title: 'Requires updates', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Notifications', exists: false },
           { title: 'Ready for review', exists: false },
           { title: 'Sent for approval', exists: false },
-          { title: 'Requires updates', exists: true },
           { title: 'In external validation', exists: false },
           { title: 'Ready to print', exists: false }
         ]
@@ -214,10 +214,10 @@ test.describe.serial('3. Workqueue flow - 3', () => {
         page,
         name: childName,
         workqueues: [
+          { title: 'Requires updates', exists: true },
           { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: false },
-          { title: 'Sent for review', exists: false },
-          { title: 'Requires updates', exists: true }
+          { title: 'Sent for review', exists: false }
         ]
       })
     })
@@ -329,9 +329,9 @@ test.describe.serial('3. Workqueue flow - 3', () => {
         page,
         name: childName,
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
           { title: 'Sent for review', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Requires updates', exists: false }
         ]
       })
@@ -346,10 +346,10 @@ test.describe.serial('3. Workqueue flow - 3', () => {
         page,
         name: childName,
         workqueues: [
+          { title: 'Ready for review', exists: true },
           { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: false },
           { title: 'Notifications', exists: false },
-          { title: 'Ready for review', exists: true },
           { title: 'Requires updates', exists: false },
           { title: 'In external validation', exists: false },
           { title: 'Ready to print', exists: false }
@@ -374,8 +374,8 @@ test.describe.serial('3. Workqueue flow - 3', () => {
         page,
         name: childName,
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Notifications', exists: false },
           { title: 'Ready for review', exists: false },
           // { title: 'Sent for approval', exists: true }, @ToDo: Investigate why this fails
@@ -395,10 +395,10 @@ test.describe.serial('3. Workqueue flow - 3', () => {
         page,
         name: childName,
         workqueues: [
+          { title: 'Ready for review', exists: true },
           { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: false },
           { title: 'Notifications', exists: false },
-          { title: 'Ready for review', exists: true },
           { title: 'Requires updates', exists: false },
           { title: 'In external validation', exists: false },
           { title: 'Ready to print', exists: false }
@@ -423,11 +423,11 @@ test.describe.serial('3. Workqueue flow - 3', () => {
         page,
         name: childName,
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
+          { title: 'Requires updates', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Notifications', exists: false },
           { title: 'Ready for review', exists: false },
-          { title: 'Requires updates', exists: true },
           { title: 'In external validation', exists: false },
           { title: 'Ready to print', exists: false }
         ]
@@ -442,11 +442,11 @@ test.describe.serial('3. Workqueue flow - 3', () => {
         page,
         name: childName,
         workqueues: [
+          { title: 'Requires updates', exists: true },
           { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: false },
           { title: 'Notifications', exists: false },
           { title: 'Ready for review', exists: false },
-          { title: 'Requires updates', exists: true },
           { title: 'Sent for approval', exists: false },
           { title: 'In external validation', exists: false },
           { title: 'Ready to print', exists: false }
@@ -469,8 +469,8 @@ test.describe.serial('3. Workqueue flow - 3', () => {
         page,
         name: childName,
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Notifications', exists: false },
           { title: 'Ready for review', exists: false },
           { title: 'Requires updates', exists: false },
@@ -489,10 +489,10 @@ test.describe.serial('3. Workqueue flow - 3', () => {
         page,
         name: childName,
         workqueues: [
+          { title: 'Ready for review', exists: true },
           { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: false },
           { title: 'Notifications', exists: false },
-          { title: 'Ready for review', exists: true },
           { title: 'Requires updates', exists: false },
           { title: 'In external validation', exists: false },
           { title: 'Ready to print', exists: false }
@@ -514,13 +514,13 @@ test.describe.serial('3. Workqueue flow - 3', () => {
         page,
         name: childName,
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
+          { title: 'Ready to print', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Notifications', exists: false },
           { title: 'Ready for review', exists: false },
           { title: 'Requires updates', exists: false },
-          { title: 'In external validation', exists: false },
-          { title: 'Ready to print', exists: true }
+          { title: 'In external validation', exists: false }
         ]
       })
     })

--- a/e2e/testcases/v2-application/workqueue-flow-4.spec.ts
+++ b/e2e/testcases/v2-application/workqueue-flow-4.spec.ts
@@ -214,9 +214,9 @@ test.describe.serial('4. Workqueue flow - 4', () => {
         page,
         name: formatName(declaration.child.name),
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
           { title: 'Sent for review', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Requires updates', exists: false }
         ]
       })
@@ -230,10 +230,10 @@ test.describe.serial('4. Workqueue flow - 4', () => {
       page,
       name: formatName(declaration.child.name),
       workqueues: [
+        { title: 'Ready for review', exists: true },
         { title: 'Assigned to you', exists: false },
         { title: 'Recent', exists: false },
         { title: 'Notifications', exists: false },
-        { title: 'Ready for review', exists: true },
         { title: 'Requires updates', exists: false },
         { title: 'In external validation', exists: false },
         { title: 'Ready to print', exists: false }
@@ -249,10 +249,10 @@ test.describe.serial('4. Workqueue flow - 4', () => {
         page,
         name: formatName(declaration.child.name),
         workqueues: [
+          { title: 'Ready for review', exists: true },
           { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: false },
           { title: 'Notifications', exists: false },
-          { title: 'Ready for review', exists: true },
           { title: 'Requires updates', exists: false },
           { title: 'Sent for approval', exists: false },
           { title: 'In external validation', exists: false },
@@ -280,8 +280,8 @@ test.describe.serial('4. Workqueue flow - 4', () => {
         page,
         name: formatName(declaration.child.name),
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Notifications', exists: false },
           { title: 'Ready for review', exists: false },
           { title: 'Requires updates', exists: false },
@@ -316,10 +316,10 @@ test.describe.serial('4. Workqueue flow - 4', () => {
         page,
         name: formatName(declaration.child.name),
         workqueues: [
+          { title: 'Ready for review', exists: true },
           { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: false },
           { title: 'Notifications', exists: false },
-          { title: 'Ready for review', exists: true },
           { title: 'Requires updates', exists: false },
           { title: 'In external validation', exists: false },
           { title: 'Ready to print', exists: false }
@@ -349,13 +349,13 @@ test.describe.serial('4. Workqueue flow - 4', () => {
         page,
         name: formatName(declaration.child.name),
         workqueues: [
-          { title: 'Assigned to you', exists: false },
           { title: 'Recent', exists: true },
+          { title: 'Ready to print', exists: true },
+          { title: 'Assigned to you', exists: false },
           { title: 'Notifications', exists: false },
           { title: 'Ready for review', exists: false },
           { title: 'Requires updates', exists: false },
-          { title: 'In external validation', exists: false },
-          { title: 'Ready to print', exists: true }
+          { title: 'In external validation', exists: false }
         ]
       })
     })
@@ -383,14 +383,14 @@ test.describe.serial('4. Workqueue flow - 4', () => {
       page,
       name: formatName(declaration.child.name),
       workqueues: [
+        { title: 'Ready to print', exists: true },
         { title: 'Assigned to you', exists: false },
         { title: 'Recent', exists: false },
         { title: 'Notifications', exists: false },
         { title: 'Ready for review', exists: false },
         { title: 'Sent for approval', exists: false },
         { title: 'Requires updates', exists: false },
-        { title: 'In external validation', exists: false },
-        { title: 'Ready to print', exists: true }
+        { title: 'In external validation', exists: false }
       ]
     })
   })

--- a/e2e/testcases/v2-birth/helpers.ts
+++ b/e2e/testcases/v2-birth/helpers.ts
@@ -4,7 +4,10 @@ import { formatName, joinValuesWith } from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { ensureOutboxIsEmpty } from '../../v2-utils'
 import { getRowByTitle } from '../v2-print-certificate/birth/helpers'
-import { SAFE_OUTBOX_TIMEOUT_MS } from '../../constants'
+import {
+  SAFE_OUTBOX_TIMEOUT_MS,
+  SAFE_WORKQUEUE_TIMEOUT_MS
+} from '../../constants'
 
 export const REQUIRED_VALIDATION_ERROR = 'Required'
 export const NAME_VALIDATION_ERROR =
@@ -85,7 +88,6 @@ export const assertRecordInWorkqueue = async ({
   name: string
   workqueues: { title: string; exists: boolean }[]
 }) => {
-  await page.getByRole('button', { name: 'Outbox' }).click()
   await ensureOutboxIsEmpty(page)
 
   for (const { title, exists } of workqueues) {

--- a/e2e/v2-utils.ts
+++ b/e2e/v2-utils.ts
@@ -108,8 +108,6 @@ export async function expectInUrl(page: Page, assertionString: string) {
 }
 
 export async function ensureOutboxIsEmpty(page: Page) {
-  await page.waitForTimeout(SAFE_INPUT_CHANGE_TIMEOUT_MS)
-
   await expect(page.locator('#navigation_workqueue_outbox')).toHaveText(
     'Outbox',
     {


### PR DESCRIPTION
## Description
1. Move positive cases first to get error cases more quickly.
2. streamline timeouts


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
