### PR TITLE
fix v1 tests

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -14,7 +14,7 @@ import fetch from 'node-fetch'
 
 export async function login(page: Page, username: string, password: string) {
   const token = await getToken(username, password)
-  await page.goto(`${CLIENT_URL}?token=${token}&V2_EVENTS=false`)
+  await page.goto(`${CLIENT_URL}?token=${token}`)
 
   await expect(
     page.locator('#appSpinner').or(page.locator('#pin-input'))
@@ -23,7 +23,7 @@ export async function login(page: Page, username: string, password: string) {
   await createPIN(page)
 
   // Navigate to v1 frontpage
-  await page.goto(`${CLIENT_URL}/registration-home`)
+  await page.goto(`${CLIENT_URL}/registration-home&V2_EVENTS=false`)
   return token
 }
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -23,7 +23,7 @@ export async function login(page: Page, username: string, password: string) {
   await createPIN(page)
 
   // Navigate to v1 frontpage
-  await page.goto(`${CLIENT_URL}/registration-home&V2_EVENTS=false`)
+  await page.goto(`${CLIENT_URL}/registration-home?V2_EVENTS=false`)
   return token
 }
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -14,11 +14,16 @@ import fetch from 'node-fetch'
 
 export async function login(page: Page, username: string, password: string) {
   const token = await getToken(username, password)
-  await page.goto(`${CLIENT_URL}?token=${token}`)
+  await page.goto(`${CLIENT_URL}?token=${token}&V2_EVENTS=false`)
 
   await expect(
     page.locator('#appSpinner').or(page.locator('#pin-input'))
   ).toBeVisible()
+
+  await createPIN(page)
+
+  // Navigate to v1 frontpage
+  await page.goto(`${CLIENT_URL}/registration-home`)
   return token
 }
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -51,7 +51,12 @@ export async function loginToV2(
   credentials = CREDENTIALS.LOCAL_REGISTRAR,
   skipPin?: boolean
 ) {
-  const token = await login(page, credentials.USERNAME, credentials.PASSWORD)
+  const token = await getToken(credentials.USERNAME, credentials.PASSWORD)
+  await page.goto(`${CLIENT_URL}?token=${token}`)
+
+  await expect(
+    page.locator('#appSpinner').or(page.locator('#pin-input'))
+  ).toBeVisible()
 
   if (!skipPin) {
     await createPIN(page)

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -14,7 +14,7 @@ import fetch from 'node-fetch'
 
 export async function login(page: Page, username: string, password: string) {
   const token = await getToken(username, password)
-  await page.goto(`${CLIENT_URL}?token=${token}&V2_EVENTS=false`)
+  await page.goto(`${CLIENT_URL}?token=${token}`)
 
   await expect(
     page.locator('#appSpinner').or(page.locator('#pin-input'))

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -14,7 +14,7 @@ import fetch from 'node-fetch'
 
 export async function login(page: Page, username: string, password: string) {
   const token = await getToken(username, password)
-  await page.goto(`${CLIENT_URL}?token=${token}`)
+  await page.goto(`${CLIENT_URL}?token=${token}&V2_EVENTS=false`)
 
   await expect(
     page.locator('#appSpinner').or(page.locator('#pin-input'))

--- a/e2e/testcases/applications/17-validate-user-can-correct-a-record-from-audit-record-page.spec.ts
+++ b/e2e/testcases/applications/17-validate-user-can-correct-a-record-from-audit-record-page.spec.ts
@@ -64,7 +64,6 @@ test.describe
       CREDENTIALS.REGISTRATION_AGENT.USERNAME,
       CREDENTIALS.REGISTRATION_AGENT.PASSWORD
     )
-    await createPIN(page)
 
     await page.getByRole('button', { name: 'Ready to print' }).click()
     await page.locator('#name_0').click()

--- a/e2e/testcases/birth/1-birth-event-declaration.spec.ts
+++ b/e2e/testcases/birth/1-birth-event-declaration.spec.ts
@@ -23,7 +23,6 @@ test.describe('1. Birth event declaration', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await expect(page.getByText('New Declaration')).toBeVisible()
       await expect(page.getByText('Event type')).toBeVisible()
@@ -441,7 +440,6 @@ test.describe('1. Birth event declaration', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Birth').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -502,7 +500,6 @@ test.describe('1. Birth event declaration', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Birth').click()
       await page.getByRole('button', { name: 'Continue' }).click()

--- a/e2e/testcases/birth/2-validate-the-child-details-page.spec.ts
+++ b/e2e/testcases/birth/2-validate-the-child-details-page.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { createPIN, goToSection, login } from '../../helpers'
+import { goToSection, login } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
 
 test.describe("2. Validate the child's details page", () => {
@@ -9,7 +9,6 @@ test.describe("2. Validate the child's details page", () => {
       CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
       CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
 
     await page.click('#header_new_event')
 

--- a/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
@@ -73,7 +73,6 @@ test.describe.serial('8. Validate declaration review page', () => {
       CREDENTIALS.FIELD_AGENT.USERNAME,
       CREDENTIALS.FIELD_AGENT.PASSWORD
     )
-    await createPIN(page)
     await page.click('#header_new_event')
     await page.getByLabel('Birth').click()
     await page.getByRole('button', { name: 'Continue' }).click()
@@ -891,7 +890,6 @@ test.describe.serial('8. Validate declaration review page', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
 
       await expect(
@@ -1152,7 +1150,6 @@ test.describe.serial('8. Validate declaration review page', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
 
       await expect(

--- a/e2e/testcases/birth/declarations/birth-declaration-1.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-1.spec.ts
@@ -93,7 +93,7 @@ test.describe.serial('1. Birth declaration case - 1', () => {
         CREDENTIALS.FIELD_AGENT.USERNAME,
         CREDENTIALS.FIELD_AGENT.PASSWORD
       )
-      await createPIN(page)
+
       await page.click('#header_new_event')
       await page.getByLabel('Birth').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -520,7 +520,6 @@ test.describe.serial('1. Birth declaration case - 1', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
 
       await expect(

--- a/e2e/testcases/birth/declarations/birth-declaration-10.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-10.spec.ts
@@ -45,7 +45,6 @@ test.describe.serial('10. Birth declaration case - 10', () => {
         CREDENTIALS.FIELD_AGENT.USERNAME,
         CREDENTIALS.FIELD_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Birth').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -218,7 +217,6 @@ test.describe.serial('10. Birth declaration case - 10', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'In Progress' }).click()
       await page.getByRole('button', { name: 'Field Agents' }).click()
 

--- a/e2e/testcases/birth/declarations/birth-declaration-2.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-2.spec.ts
@@ -108,7 +108,6 @@ test.describe.serial('2. Birth declaration case - 2', () => {
         CREDENTIALS.FIELD_AGENT.USERNAME,
         CREDENTIALS.FIELD_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Birth').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -565,7 +564,6 @@ test.describe.serial('2. Birth declaration case - 2', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
 
       await expect(

--- a/e2e/testcases/birth/declarations/birth-declaration-3.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-3.spec.ts
@@ -127,7 +127,6 @@ test.describe.serial('3. Birth declaration case - 3', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Birth').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -751,7 +750,6 @@ test.describe.serial('3. Birth declaration case - 3', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
 
       await expect(

--- a/e2e/testcases/birth/declarations/birth-declaration-4.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-4.spec.ts
@@ -127,7 +127,6 @@ test.describe.serial('4. Birth declaration case - 4', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Birth').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -670,7 +669,6 @@ test.describe.serial('4. Birth declaration case - 4', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
 
       await expect(

--- a/e2e/testcases/birth/declarations/birth-declaration-5.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-5.spec.ts
@@ -103,7 +103,6 @@ test.describe.serial('5. Birth declaration case - 5', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Birth').click()
       await page.getByRole('button', { name: 'Continue' }).click()

--- a/e2e/testcases/birth/declarations/birth-declaration-6.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-6.spec.ts
@@ -105,7 +105,6 @@ test.describe.serial('6. Birth declaration case - 6', () => {
         CREDENTIALS.NATIONAL_REGISTRAR.USERNAME,
         CREDENTIALS.NATIONAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Birth').click()
       await page.getByRole('button', { name: 'Continue' }).click()

--- a/e2e/testcases/birth/declarations/birth-declaration-7.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-7.spec.ts
@@ -50,7 +50,6 @@ test.describe.serial('7. Birth declaration case - 7', () => {
         CREDENTIALS.FIELD_AGENT.USERNAME,
         CREDENTIALS.FIELD_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Birth').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -269,7 +268,6 @@ test.describe.serial('7. Birth declaration case - 7', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'In Progress' }).click()
       await page.getByRole('button', { name: 'Field Agents' }).click()
 

--- a/e2e/testcases/birth/declarations/birth-declaration-8.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-8.spec.ts
@@ -41,7 +41,6 @@ test.describe.serial('8. Birth declaration case - 8', () => {
         CREDENTIALS.FIELD_AGENT.USERNAME,
         CREDENTIALS.FIELD_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Birth').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -277,7 +276,6 @@ test.describe.serial('8. Birth declaration case - 8', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'In Progress' }).click()
       await page.getByRole('button', { name: 'Field Agents' }).click()
 

--- a/e2e/testcases/birth/declarations/birth-declaration-9.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-9.spec.ts
@@ -45,7 +45,6 @@ test.describe.serial('9. Birth declaration case - 9', () => {
         CREDENTIALS.FIELD_AGENT.USERNAME,
         CREDENTIALS.FIELD_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Birth').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -217,7 +216,6 @@ test.describe.serial('9. Birth declaration case - 9', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'In Progress' }).click()
       await page.getByRole('button', { name: 'Field Agents' }).click()
 

--- a/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
@@ -91,7 +91,6 @@ test.describe('1. Correct record - 1', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
 
       await auditRecord({
         page,
@@ -249,7 +248,6 @@ test.describe('1. Correct record - 1', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
 
       await auditRecord({
         page,
@@ -823,7 +821,6 @@ test.describe('1. Correct record - 1', () => {
           CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
           CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
         )
-        await createPIN(page)
       })
 
       test('1.2.6.1 Record audit by local registrar', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
@@ -119,7 +119,6 @@ test.describe.serial('Correct record - 2', () => {
       CREDENTIALS.REGISTRATION_AGENT.USERNAME,
       CREDENTIALS.REGISTRATION_AGENT.PASSWORD
     )
-    await createPIN(page)
 
     await auditRecord({
       page,
@@ -918,7 +917,6 @@ test.describe.serial('Correct record - 2', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
     })
 
     test('2.8.1 Record audit by local registrar', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-3.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-3.spec.ts
@@ -117,7 +117,6 @@ test.describe.serial(' Correct record - 3', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
 
       await auditRecord({
         page,
@@ -895,7 +894,6 @@ test.describe.serial(' Correct record - 3', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
     })
 
     test('3.8.1 Record audit by local registrar', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
@@ -119,7 +119,6 @@ test.describe.serial(' Correct record - 4', () => {
       CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
       CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
 
     await auditRecord({
       page,

--- a/e2e/testcases/correction-birth/correct-birth-record-5.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-5.spec.ts
@@ -112,7 +112,6 @@ test.describe.serial(' Correct record - 5', () => {
       CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
       CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
 
     await auditRecord({
       page,

--- a/e2e/testcases/correction-birth/correct-birth-record-6.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-6.spec.ts
@@ -104,7 +104,6 @@ test.describe.serial(' Correct record - 6', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
 
       await auditRecord({
         page,

--- a/e2e/testcases/correction-birth/correct-birth-record-7.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-7.spec.ts
@@ -105,7 +105,6 @@ test.describe.serial(' Correct record - 7', () => {
       CREDENTIALS.NATIONAL_REGISTRAR.USERNAME,
       CREDENTIALS.NATIONAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
 
     await auditRecord({
       page,

--- a/e2e/testcases/correction-birth/correct-birth-record-8.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-8.spec.ts
@@ -105,7 +105,6 @@ test.describe.serial(' Correct record - 8', () => {
       CREDENTIALS.NATIONAL_REGISTRAR.USERNAME,
       CREDENTIALS.NATIONAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
 
     await auditRecord({
       page,

--- a/e2e/testcases/correction-birth/correct-birth-record-9.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-9.spec.ts
@@ -104,7 +104,6 @@ test.describe.serial(' Correct record - 9', () => {
         CREDENTIALS.NATIONAL_REGISTRAR.USERNAME,
         CREDENTIALS.NATIONAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
 
       await auditRecord({
         page,

--- a/e2e/testcases/correction-death/correct-death-record-10.spec.ts
+++ b/e2e/testcases/correction-death/correct-death-record-10.spec.ts
@@ -74,7 +74,6 @@ test.describe('10. Correct record - 10', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
 
       await auditRecord({
         page,
@@ -208,7 +207,6 @@ test.describe('10. Correct record - 10', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
 
       await auditRecord({
         page,
@@ -928,7 +926,6 @@ test.describe('10. Correct record - 10', () => {
           CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
           CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
         )
-        await createPIN(page)
       })
 
       test('10.2.6.1 Record audit by local registrar', async () => {

--- a/e2e/testcases/correction-death/correct-death-record-11.spec.ts
+++ b/e2e/testcases/correction-death/correct-death-record-11.spec.ts
@@ -74,7 +74,6 @@ test.describe.serial(' Correct record - 11', () => {
       CREDENTIALS.REGISTRATION_AGENT.USERNAME,
       CREDENTIALS.REGISTRATION_AGENT.PASSWORD
     )
-    await createPIN(page)
 
     await auditRecord({
       page,
@@ -463,7 +462,6 @@ test.describe.serial(' Correct record - 11', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
     })
 
     test('11.8.1 Record audit by local registrar', async () => {

--- a/e2e/testcases/correction-death/correct-death-record-12.spec.ts
+++ b/e2e/testcases/correction-death/correct-death-record-12.spec.ts
@@ -112,7 +112,6 @@ test.describe.serial(' Correct record - 12', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
 
       await auditRecord({
         page,
@@ -866,7 +865,6 @@ test.describe.serial(' Correct record - 12', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
     })
 
     test('12.8.1 Record audit by local registrar', async () => {

--- a/e2e/testcases/correction-death/correct-death-record-13.spec.ts
+++ b/e2e/testcases/correction-death/correct-death-record-13.spec.ts
@@ -99,7 +99,6 @@ test.describe.serial(' Correct record - 13', () => {
       CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
       CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
 
     await auditRecord({
       page,

--- a/e2e/testcases/correction-death/correct-death-record-14.spec.ts
+++ b/e2e/testcases/correction-death/correct-death-record-14.spec.ts
@@ -77,7 +77,6 @@ test.describe.serial(' Correct record - 14', () => {
       CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
       CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
 
     await auditRecord({
       page,

--- a/e2e/testcases/correction-death/correct-death-record-15.spec.ts
+++ b/e2e/testcases/correction-death/correct-death-record-15.spec.ts
@@ -78,7 +78,6 @@ test.describe.serial(' Correct record - 15', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
 
       await auditRecord({
         page,

--- a/e2e/testcases/correction-death/correct-death-record-16.spec.ts
+++ b/e2e/testcases/correction-death/correct-death-record-16.spec.ts
@@ -83,7 +83,6 @@ test.describe.serial(' Correct record - 16', () => {
       CREDENTIALS.NATIONAL_REGISTRAR.USERNAME,
       CREDENTIALS.NATIONAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
 
     await auditRecord({
       page,

--- a/e2e/testcases/correction-death/correct-death-record-17.spec.ts
+++ b/e2e/testcases/correction-death/correct-death-record-17.spec.ts
@@ -79,7 +79,6 @@ test.describe.serial(' Correct record - 17', () => {
       CREDENTIALS.NATIONAL_REGISTRAR.USERNAME,
       CREDENTIALS.NATIONAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
 
     await auditRecord({
       page,

--- a/e2e/testcases/correction-death/correct-death-record-18.spec.ts
+++ b/e2e/testcases/correction-death/correct-death-record-18.spec.ts
@@ -77,7 +77,6 @@ test.describe.serial(' Correct record - 18', () => {
         CREDENTIALS.NATIONAL_REGISTRAR.USERNAME,
         CREDENTIALS.NATIONAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
 
       await auditRecord({
         page,

--- a/e2e/testcases/death/1-death-event-declaration.spec.ts
+++ b/e2e/testcases/death/1-death-event-declaration.spec.ts
@@ -20,7 +20,6 @@ test.describe('1. Death event declaration', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await expect(page.getByText('New Declaration')).toBeVisible()
       await expect(page.getByText('Event type')).toBeVisible()
@@ -421,7 +420,6 @@ test.describe('1. Death event declaration', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Death').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -482,7 +480,6 @@ test.describe('1. Death event declaration', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Death').click()
       await page.getByRole('button', { name: 'Continue' }).click()

--- a/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
@@ -73,7 +73,6 @@ test.describe.serial('8. Validate declaration review page', () => {
       CREDENTIALS.FIELD_AGENT.USERNAME,
       CREDENTIALS.FIELD_AGENT.PASSWORD
     )
-    await createPIN(page)
     await page.click('#header_new_event')
     await page.getByLabel('Death').click()
     await page.getByRole('button', { name: 'Continue' }).click()
@@ -738,7 +737,6 @@ test.describe.serial('8. Validate declaration review page', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
 
       await expect(
@@ -1218,7 +1216,6 @@ test.describe.serial('8. Validate declaration review page', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
 
       await expect(

--- a/e2e/testcases/death/declaration/death-declaration-1.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-1.spec.ts
@@ -88,7 +88,6 @@ test.describe.serial('1. Death declaration case - 1', () => {
         CREDENTIALS.FIELD_AGENT.USERNAME,
         CREDENTIALS.FIELD_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Death').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -473,7 +472,6 @@ test.describe.serial('1. Death declaration case - 1', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
 
       await expect(

--- a/e2e/testcases/death/declaration/death-declaration-10.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-10.spec.ts
@@ -40,7 +40,6 @@ test.describe.serial('10. Death declaration case - 10', () => {
         CREDENTIALS.FIELD_AGENT.USERNAME,
         CREDENTIALS.FIELD_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Death').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -261,7 +260,6 @@ test.describe.serial('10. Death declaration case - 10', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'In Progress' }).click()
       await page.getByRole('button', { name: 'Field Agents' }).click()
 

--- a/e2e/testcases/death/declaration/death-declaration-11.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-11.spec.ts
@@ -119,7 +119,6 @@ test.describe.serial('11. Death declaration case - 11', () => {
         CREDENTIALS.FIELD_AGENT.USERNAME,
         CREDENTIALS.FIELD_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Death').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -806,7 +805,6 @@ test.describe.serial('11. Death declaration case - 11', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
 
       await expect(

--- a/e2e/testcases/death/declaration/death-declaration-2.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-2.spec.ts
@@ -110,7 +110,6 @@ test.describe.serial('2. Death declaration case - 2', () => {
         CREDENTIALS.FIELD_AGENT.USERNAME,
         CREDENTIALS.FIELD_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Death').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -684,7 +683,6 @@ test.describe.serial('2. Death declaration case - 2', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
 
       await expect(

--- a/e2e/testcases/death/declaration/death-declaration-3.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-3.spec.ts
@@ -117,7 +117,6 @@ test.describe.serial('3. Death declaration case - 3', () => {
         CREDENTIALS.FIELD_AGENT.USERNAME,
         CREDENTIALS.FIELD_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Death').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -644,7 +643,6 @@ test.describe.serial('3. Death declaration case - 3', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
 
       await expect(

--- a/e2e/testcases/death/declaration/death-declaration-4.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-4.spec.ts
@@ -115,7 +115,6 @@ test.describe.serial('4. Death declaration case - 4', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Death').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -639,7 +638,6 @@ test.describe.serial('4. Death declaration case - 4', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
 
       await expect(

--- a/e2e/testcases/death/declaration/death-declaration-5.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-5.spec.ts
@@ -107,7 +107,6 @@ test.describe.serial('5. Death declaration case - 5', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Death').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -550,7 +549,6 @@ test.describe.serial('5. Death declaration case - 5', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
 
       await expect(

--- a/e2e/testcases/death/declaration/death-declaration-6.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-6.spec.ts
@@ -103,7 +103,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
         CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
         CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
+
       await page.click('#header_new_event')
       await page.getByLabel('Death').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -531,7 +531,6 @@ test.describe.serial('6. Death declaration case - 6', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready to print' }).click()
       await page
         .getByRole('button', {

--- a/e2e/testcases/death/declaration/death-declaration-7.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-7.spec.ts
@@ -106,7 +106,6 @@ test.describe.serial('7. Death declaration case - 7', () => {
         CREDENTIALS.NATIONAL_REGISTRAR.USERNAME,
         CREDENTIALS.NATIONAL_REGISTRAR.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Death').click()
       await page.getByRole('button', { name: 'Continue' }).click()

--- a/e2e/testcases/death/declaration/death-declaration-8.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-8.spec.ts
@@ -48,7 +48,6 @@ test.describe.serial('8. Death declaration case - 8', () => {
         CREDENTIALS.FIELD_AGENT.USERNAME,
         CREDENTIALS.FIELD_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Death').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -287,7 +286,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
+
       await page.getByRole('button', { name: 'In Progress' }).click()
       await page.getByRole('button', { name: 'Field Agents' }).click()
 

--- a/e2e/testcases/death/declaration/death-declaration-9.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-9.spec.ts
@@ -46,7 +46,6 @@ test.describe.serial('9. Death declaration case - 9', () => {
         CREDENTIALS.FIELD_AGENT.USERNAME,
         CREDENTIALS.FIELD_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Death').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -285,7 +284,6 @@ test.describe.serial('9. Death declaration case - 9', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'In Progress' }).click()
       await page.getByRole('button', { name: 'Field Agents' }).click()
 

--- a/e2e/testcases/integrations/system-client.spec.ts
+++ b/e2e/testcases/integrations/system-client.spec.ts
@@ -27,7 +27,6 @@ test.describe.serial('Record Search System Client Tests', () => {
       CREDENTIALS.NATIONAL_SYSTEM_ADMIN.USERNAME,
       CREDENTIALS.NATIONAL_SYSTEM_ADMIN.PASSWORD
     )
-    await createPIN(page)
   })
 
   test.afterAll(async () => {
@@ -141,7 +140,6 @@ test.describe.serial('Event Notification System Client Tests', () => {
       CREDENTIALS.NATIONAL_SYSTEM_ADMIN.USERNAME,
       CREDENTIALS.NATIONAL_SYSTEM_ADMIN.PASSWORD
     )
-    await createPIN(page)
   })
 
   test.afterAll(async () => {

--- a/e2e/testcases/login/1-login-with-valid-information.spec.ts
+++ b/e2e/testcases/login/1-login-with-valid-information.spec.ts
@@ -34,10 +34,5 @@ test.describe('1. Login with valid information', () => {
 
     await page.fill('#code', '000000')
     await page.click('#login-mobile-submit')
-
-    // Expected result: Must log in to the OPENCRVS Page
-    await expect(
-      page.locator('#appSpinner').or(page.locator('#pin-input'))
-    ).toBeVisible()
   })
 })

--- a/e2e/testcases/marriage/1-marriage-event-declaration.spec.ts
+++ b/e2e/testcases/marriage/1-marriage-event-declaration.spec.ts
@@ -10,7 +10,6 @@ test.describe('1. Marriage event validation', () => {
       CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
       CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
   })
 
   test('1.1. Navigate to the event declaration page', async ({ page }) => {

--- a/e2e/testcases/marriage/4-validate-groom-details-page.spec.ts
+++ b/e2e/testcases/marriage/4-validate-groom-details-page.spec.ts
@@ -4,7 +4,6 @@ import { createPIN, goToSection, login } from '../../helpers'
 test.describe("4. Validate the groom's details page", () => {
   test.beforeEach(async ({ page }) => {
     await login(page, 'k.mweene', 'test')
-    await createPIN(page)
 
     await page.click('#header_new_event')
 

--- a/e2e/testcases/marriage/5-validate-bride-details-page.spec.ts
+++ b/e2e/testcases/marriage/5-validate-bride-details-page.spec.ts
@@ -4,7 +4,6 @@ import { createPIN, goToSection, login } from '../../helpers'
 test.describe("5. Validate the bride's details page", () => {
   test.beforeEach(async ({ page }) => {
     await login(page, 'k.mweene', 'test')
-    await createPIN(page)
 
     await page.click('#header_new_event')
 

--- a/e2e/testcases/marriage/6-details-page-validation.spec.ts
+++ b/e2e/testcases/marriage/6-details-page-validation.spec.ts
@@ -9,7 +9,6 @@ test.describe('6. Validate Marriage details page', () => {
       CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
       CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
     await page.click('#header_new_event')
     await page.getByText('Marriage', { exact: true }).click()
     await page.getByText('Continue', { exact: true }).click()

--- a/e2e/testcases/marriage/7-validate-witness-1-page.spec.ts
+++ b/e2e/testcases/marriage/7-validate-witness-1-page.spec.ts
@@ -9,7 +9,6 @@ test.describe('7. Validate Witness 1 details page', () => {
       CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
       CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
     await page.click('#header_new_event')
     await page.getByText('Marriage', { exact: true }).click()
     await goToSection(page, 'witnessOne')

--- a/e2e/testcases/marriage/7-validate-witness-2-page.spec.ts
+++ b/e2e/testcases/marriage/7-validate-witness-2-page.spec.ts
@@ -9,7 +9,6 @@ test.describe('7. Validate Witness 2 details page', () => {
       CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
       CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
     await page.click('#header_new_event')
     await page.getByText('Marriage', { exact: true }).click()
     await goToSection(page, 'witnessTwo')

--- a/e2e/testcases/marriage/declaration/marriage-declaration-1.spec.ts
+++ b/e2e/testcases/marriage/declaration/marriage-declaration-1.spec.ts
@@ -117,7 +117,6 @@ test.describe.serial('1. Marriage declaration case - 1', () => {
         CREDENTIALS.FIELD_AGENT.USERNAME,
         CREDENTIALS.FIELD_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.click('#header_new_event')
       await page.getByLabel('Marriage').click()
       await page.getByRole('button', { name: 'Continue' }).click()
@@ -634,7 +633,6 @@ test.describe.serial('1. Marriage declaration case - 1', () => {
         CREDENTIALS.REGISTRATION_AGENT.USERNAME,
         CREDENTIALS.REGISTRATION_AGENT.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Ready for review' }).click()
       await page
         .getByRole('button', {

--- a/e2e/testcases/print-certificate/birth/certificate-helper.ts
+++ b/e2e/testcases/print-certificate/birth/certificate-helper.ts
@@ -61,7 +61,6 @@ export async function getDeclarationForPrintCertificate(
       CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
       CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
   }
 
   await page.getByPlaceholder('Search for a tracking ID').fill(trackingId)

--- a/e2e/testcases/print-certificate/death/certificate-helper.ts
+++ b/e2e/testcases/print-certificate/death/certificate-helper.ts
@@ -42,7 +42,6 @@ export async function getDeathDeclarationForPrintCertificate(
       CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
       CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
     )
-    await createPIN(page)
   }
 
   await page.getByPlaceholder('Search for a tracking ID').fill(trackingId)

--- a/e2e/testcases/team/user-creation-registrar.spec.ts
+++ b/e2e/testcases/team/user-creation-registrar.spec.ts
@@ -38,7 +38,6 @@ test.describe.serial('1. Create user -1', () => {
         CREDENTIALS.NATIONAL_SYSTEM_ADMIN.USERNAME,
         CREDENTIALS.NATIONAL_SYSTEM_ADMIN.PASSWORD
       )
-      await createPIN(page)
       await page.getByRole('button', { name: 'Team' }).click()
       await expect(page.getByText('HQ Office')).toBeVisible()
       await page.click('#add-user')


### PR DESCRIPTION
## Description

At some point we have made v2 the default on e2e deployments. This broke v1 tests, as the login on v1 tests navigated to v2.

Now we navigate to v1 frontpage when logging in on v1 tests.