### PR TITLE
chore: add test cases for navigation content

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -49,11 +49,15 @@ export async function logout(page: Page) {
 export async function loginToV2(
   page: Page,
   credentials = CREDENTIALS.LOCAL_REGISTRAR,
-  skipPin?: boolean
+  skipPin?: boolean,
+  /** whether to render v2 as first class citizen, sets V2 as the default view. */
+  defaultToV2?: boolean
 ) {
   const token = await getToken(credentials.USERNAME, credentials.PASSWORD)
   expect(token).toBeDefined()
-  await page.goto(`${CLIENT_URL}?token=${token}`)
+  await page.goto(
+    `${CLIENT_URL}?token=${token}${defaultToV2 ? '&V2_EVENTS=true' : ''}`
+  )
 
   await expect(
     page.locator('#appSpinner').or(page.locator('#pin-input'))
@@ -63,8 +67,7 @@ export async function loginToV2(
     await createPIN(page)
   }
 
-  // Navigate to the v2 client
-  await page.goto(CLIENT_V2_URL)
+  await page.goto(defaultToV2 ? CLIENT_URL : CLIENT_V2_URL)
 
   return token
 }

--- a/e2e/testcases/v2-application/side-navigation.spec.ts
+++ b/e2e/testcases/v2-application/side-navigation.spec.ts
@@ -165,7 +165,8 @@ test.describe.serial('Side navigation', () => {
       await expect(page.locator(items[1])).toBeHidden()
 
       await page.getByRole('button', { name: items[0] }).click()
-      await expect(page.locator(items[1])).toBeVisible()
+
+      await page.getByRole('button', { name: items[1] }).click()
     }
 
     for (const item of nationalSystemAdminNavItemsWithoutFrame) {

--- a/e2e/testcases/v2-application/side-navigation.spec.ts
+++ b/e2e/testcases/v2-application/side-navigation.spec.ts
@@ -141,7 +141,7 @@ test.describe.serial('Side navigation', () => {
 
     const nationalSystemAdminNestedNavItemsWithFrame = [
       ['Communications', 'Email all users'],
-      ['Configurations', 'Integrations']
+      ['Configuration', 'Integrations']
     ]
 
     for (const item of nationalSystemAdminNavItemsWithFrame) {

--- a/e2e/testcases/v2-application/side-navigation.spec.ts
+++ b/e2e/testcases/v2-application/side-navigation.spec.ts
@@ -1,0 +1,179 @@
+import { test, type Page, expect } from '@playwright/test'
+import { loginToV2 } from '../../helpers'
+import { CREDENTIALS } from '../../constants'
+
+test.describe.serial('Side navigation', () => {
+  let page: Page
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+  })
+
+  test.afterAll(async () => {
+    await page.close()
+  })
+
+  test('1.1. Check LOCAL REGISTRAR navigation items', async () => {
+    await loginToV2(page, CREDENTIALS.LOCAL_REGISTRAR, false, true)
+
+    // V2 workques is super set of V1 workqueues.
+    const localRegisrarWorkqueues = [
+      'Outbox',
+      'My drafts',
+      'Assigned to you',
+      'Recent',
+      'Notifications',
+      'Ready for review',
+      'Requires updates',
+      'In external validation',
+      'Ready to Print'
+    ]
+
+    // All workqueues are present on home page.
+    for (const item of localRegisrarWorkqueues) {
+      page.getByRole('button', { name: item })
+    }
+
+    const localRegistrarNavItemsWithFrame = ['Organisation', 'Team']
+
+    const localRegistrarNavItemsWithoutFrame = [
+      'Dashboard',
+      'Statistics',
+      'Leaderboards'
+    ]
+
+    for (const item of localRegistrarNavItemsWithFrame) {
+      await page.getByRole('button', { name: item }).click()
+
+      // All workqueues are present on each page. V1 have different workqueues, so we should notice.
+      for (const item of localRegisrarWorkqueues) {
+        page.getByRole('button', { name: item })
+      }
+      // All workqueues are present on each page. V1 have different workqueues, so we should notice.
+      for (const item of localRegistrarNavItemsWithoutFrame) {
+        page.getByRole('button', { name: item })
+      }
+    }
+
+    for (const item of localRegistrarNavItemsWithoutFrame) {
+      await page.getByRole('button', { name: item }).click()
+      await expect(page.locator('Farajaland CRS')).toBeHidden()
+
+      // Only one button available (X)
+      await page.getByRole('button').click()
+    }
+  })
+
+  test('1.2. Check REGISTRATION AGENT navigation items', async () => {
+    await loginToV2(page, CREDENTIALS.REGISTRATION_AGENT, false, true)
+
+    // V2 workques is super set of V1 workqueues.
+    const registrationAgentWorkqueues = [
+      'Outbox',
+      'My drafts',
+      'Assigned to you',
+      'Recent',
+      'Notifications',
+      'Ready for review',
+      'Requires updates',
+      'In external validation',
+      'Ready to Print'
+    ]
+
+    // All workqueues are present on home page.
+    for (const item of registrationAgentWorkqueues) {
+      page.getByText(item)
+    }
+
+    const registrationAgentNavItemsWithFrame = ['Organisation', 'Team']
+
+    const registrationAgentNavItemsWithoutFrame = [
+      'Dashboard',
+      'Statistics',
+      'Leaderboards'
+    ]
+
+    for (const item of registrationAgentNavItemsWithFrame) {
+      await page.getByText(item).click()
+
+      // All workqueues are present on each page. V1 have different workqueues, so we should notice.
+      for (const item of registrationAgentWorkqueues) {
+        page.getByText(item)
+      }
+      // All workqueues are present on each page. V1 have different workqueues, so we should notice.
+      for (const item of registrationAgentNavItemsWithoutFrame) {
+        page.getByText(item)
+      }
+    }
+
+    for (const item of registrationAgentNavItemsWithoutFrame) {
+      await page.getByText(item).click()
+      await expect(page.locator('Farajaland CRS')).toBeHidden()
+
+      // Only one button available (X)
+      await page.getByRole('button').click()
+    }
+  })
+
+  test('1.3. Check NATIONAL_SYSTEM_ADMIN navigation items', async () => {
+    await loginToV2(page, CREDENTIALS.NATIONAL_SYSTEM_ADMIN, false, true)
+
+    const nationalSystemAdminNavItemsWithFrame = ['Organisation', 'Team']
+
+    const nationalSystemAdminNavItemsWithoutFrame = [
+      'Dashboard',
+      'Statistics',
+      'Leaderboards'
+    ]
+
+    // Should not have any workqueues, check that none of the workqueues are present
+    const registrationAgentWorkqueues = [
+      'Outbox',
+      'My drafts',
+      'Assigned to you',
+      'Recent',
+      'Notifications',
+      'Ready for review',
+      'Requires updates',
+      'In external validation',
+      'Ready to Print'
+    ]
+
+    const nationalSystemAdminNestedNavItemsWithFrame = [
+      ['Communications', 'Email all users'],
+      ['Configurations', 'Integrations']
+    ]
+
+    for (const item of nationalSystemAdminNavItemsWithFrame) {
+      await page.getByRole('button', { name: item }).click()
+
+      for (const item of registrationAgentWorkqueues) {
+        await expect(page.locator(item)).toBeHidden()
+      }
+
+      for (const items of nationalSystemAdminNestedNavItemsWithFrame) {
+        page.getByRole('button', { name: items[0] })
+        await expect(page.locator(items[1])).toBeHidden()
+      }
+
+      for (const item of nationalSystemAdminNavItemsWithoutFrame) {
+        page.getByRole('button', { name: item })
+      }
+    }
+
+    for (const items of nationalSystemAdminNestedNavItemsWithFrame) {
+      await expect(page.locator(items[1])).toBeHidden()
+
+      await page.getByRole('button', { name: items[0] }).click()
+      await expect(page.locator(items[1])).toBeVisible()
+    }
+
+    for (const item of nationalSystemAdminNavItemsWithoutFrame) {
+      await page.getByRole('button', { name: item }).click()
+      await expect(page.locator('Farajaland CRS')).toBeHidden()
+
+      // Only one button available (X)
+      await page.getByRole('button').click()
+    }
+  })
+})


### PR DESCRIPTION
## Description

Add test cases to check that V2 navigation remains when going through navigation

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
