### PR TITLE
fix: BRN lookup field only allows birth.

### DIFF
--- a/src/events/death/forms/pages/deceased.ts
+++ b/src/events/death/forms/pages/deceased.ts
@@ -107,6 +107,9 @@ export const deceased = defineFormPage({
                 term: '{term}',
                 type: 'exact'
               }
+            },
+            {
+              eventType: 'birth'
             }
           ]
         },


### PR DESCRIPTION
## Description

As Elasticsearch contains all events in one index/alias, if a user enters a Death Registration Number (DRN), the system find a match in the death records. Since a result is returned, the frontend incorrectly displays "BRN Found".

just added a new clause

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
