### PR TITLE
fix: amend location handlebars in svgs

### DIFF
--- a/src/api/certificates/source/v2.birth-certificate-certified-copy.svg
+++ b/src/api/certificates/source/v2.birth-certificate-certified-copy.svg
@@ -175,12 +175,10 @@
         <tspan x="307" y="220.104">{{$join ", " ($lookup $declaration 'child.birthLocation.district') ($lookup $declaration 'child.birthLocation.province') ($lookup $declaration 'child.birthLocation.country')}}</tspan>
       {{else}}
         {{#ifCond ($lookup $declaration 'child.birthLocation.other') '!==' undefined }}
-        <tspan x="307" y="208.104">{{$or ($lookup $declaration 'child.birthLocation.other.district') ($lookup $declaration 'child.birthLocation.other.streetLevelDetails.district2')}}&#10;</tspan>
-        <tspan x="307" y="220.104">{{$join ", " ($or ($lookup $declaration 'child.birthLocation.other.streetLevelDetails.state') ($lookup $declaration 'child.birthLocation.other.province')) ($lookup $declaration 'child.birthLocation.other.country')}}</tspan>
+        <tspan x="307" y="208.104">{{$lookup $declaration 'child.birthLocation.other.administrativeHierarchy'}}</tspan>
         {{else}}
           {{#ifCond ($lookup $declaration 'child.birthLocation.privateHome') '!==' undefined }}
-            <tspan x="307" y="208.104">{{$or ($lookup $declaration 'child.birthLocation.privateHome.district') ($lookup $declaration 'child.birthLocation.privateHome.streetLevelDetails.district2')}}&#10;</tspan>
-            <tspan x="307" y="220.104">{{$join ", " ($or ($lookup $declaration 'child.birthLocation.privateHome.streetLevelDetails.state') ($lookup $declaration 'child.birthLocation.privateHome.province')) ($lookup $declaration 'child.birthLocation.privateHome.country')}}</tspan>
+            <tspan x="307" y="208.104">{{$lookup $declaration 'child.birthLocation.privateHome.administrativeHierarchy'}}</tspan>
           {{/ifCond}}
         {{/ifCond}}
       {{/ifCond}}
@@ -325,7 +323,7 @@
         {{#ifCond (lookup $declaration 'father.addressSameAs') '===' 'YES'}}
           <tspan x="307" y="432.104">{{$lookup $declaration 'mother.address.administrativeHierarchy'}}</tspan>
         {{else}}
-          <tspan x="307" y="432.104">{{$join ", " ($or ($lookup $declaration 'father.address.district') ($lookup $declaration 'father.address.streetLevelDetails.district2')) ($or ($lookup $declaration 'father.address.province') ($lookup $declaration 'father.address.streetLevelDetails.state')) ($lookup $declaration 'father.address.country')}}</tspan>
+          <tspan x="307" y="432.104">{{$lookup $declaration 'father.address.administrativeHierarchy'}}</tspan>
         {{/ifCond}}
       {{/ifCond}}
     </text>
@@ -402,7 +400,7 @@
   <g clip-path="url(#clip17_946_2501)">
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
       font-size="8" letter-spacing="0px">
-      <tspan x="307" y="550.104">{{$join ", " ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.district") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.province") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.country")}}</tspan>
+      <tspan x="307" y="550.104">{{$join ", " ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.name") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.district") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.province") ($lookup $metadata "legalStatuses.REGISTERED.createdAtLocation.country")}}</tspan>
     </text>
   </g>
   <line x1="65" y1="556.5" x2="533" y2="556.5" stroke="#ECECEC" />

--- a/src/api/certificates/source/v2.birth-certificate.svg
+++ b/src/api/certificates/source/v2.birth-certificate.svg
@@ -209,12 +209,10 @@
         <tspan x="289.95" y="362.054">{{$join ", " ($lookup $declaration 'child.birthLocation.district') ($lookup $declaration 'child.birthLocation.province') ($lookup $declaration 'child.birthLocation.country')}}</tspan>
       {{else}}
         {{#ifCond ($lookup $declaration 'child.birthLocation.other') '!==' undefined }}
-          <tspan x="289.95" y="347.054">{{$or ($lookup $declaration 'child.birthLocation.other.district') ($lookup $declaration 'child.birthLocation.other.streetLevelDetails.district2')}}&#10;</tspan>
-          <tspan x="289.95" y="362.054">{{$join ", " ($or ($lookup $declaration 'child.birthLocation.other.streetLevelDetails.state') ($lookup $declaration 'child.birthLocation.other.province')) ($lookup $declaration 'child.birthLocation.other.country')}}</tspan>
+          <tspan x="289.95" y="347.054">{{$lookup $declaration 'child.birthLocation.other.administrativeHierarchy'}}</tspan>
         {{else}}
           {{#ifCond ($lookup $declaration 'child.birthLocation.privateHome') '!==' undefined }}
-            <tspan x="289.95" y="347.054">{{$or ($lookup $declaration 'child.birthLocation.privateHome.district') ($lookup $declaration 'child.birthLocation.privateHome.streetLevelDetails.district2')}}&#10;</tspan>
-            <tspan x="289.95" y="362.054">{{$join ", " ($or ($lookup $declaration 'child.birthLocation.privateHome.streetLevelDetails.state') ($lookup $declaration 'child.birthLocation.privateHome.province')) ($lookup $declaration 'child.birthLocation.privateHome.country')}}</tspan>
+            <tspan x="289.95" y="347.054">{{$lookup $declaration 'child.birthLocation.privateHome.administrativeHierarchy'}}</tspan>
           {{/ifCond}}
         {{/ifCond}}
       {{/ifCond}}

--- a/src/api/certificates/source/v2.death-certificate-certified-copy.svg
+++ b/src/api/certificates/source/v2.death-certificate-certified-copy.svg
@@ -147,8 +147,7 @@
           <tspan x="312" y="306.104">{{$join ", " ($lookup $declaration 'eventDetails.deathLocation.district') ($lookup $declaration 'eventDetails.deathLocation.province') ($lookup $declaration 'eventDetails.deathLocation.country')}}</tspan>
         {{else}}
           {{#ifCond ($lookup $declaration 'eventDetails.deathLocationOther') '!==' undefined }}
-          <tspan x="312" y="294.104">{{$or ($lookup $declaration 'eventDetails.deathLocationOther.district') ($lookup $declaration 'eventDetails.deathLocationOther.streetLevelDetails.district2')}}&#10;</tspan>
-          <tspan x="312" y="306.104">{{$join ", " ($or ($lookup $declaration 'eventDetails.deathLocationOther.streetLevelDetails.state') ($lookup $declaration 'eventDetails.deathLocationOther.province')) ($lookup $declaration 'eventDetails.deathLocationOther.country')}}</tspan>
+          <tspan x="312" y="294.104">{{$lookup $declaration 'eventDetails.deathLocationOther.administrativeHierarchy'}}</tspan>
           {{else}}
             {{#ifCond ($lookup $declaration 'deceased.address') '!==' undefined }}
             <tspan x="312" y="294.104">{{$or ($lookup $declaration 'deceased.address.district') ($lookup $declaration 'deceased.address.streetLevelDetails.district2')}}&#10;</tspan>

--- a/src/api/certificates/source/v2.death-certificate-certified-copy.svg
+++ b/src/api/certificates/source/v2.death-certificate-certified-copy.svg
@@ -201,7 +201,7 @@
   </text>
   <g clip-path="url(#clip9_948_2918)">
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px">
-      <tspan x="312" y="404.104">{{$join ", " ($lookup $metadata 'legalStatuses.REGISTERED.createdAtLocation.district') ($lookup $metadata 'legalStatuses.REGISTERED.createdAtLocation.province') ($lookup $metadata 'legalStatuses.REGISTERED.createdAtLocation.country')}}</tspan>
+      <tspan x="312" y="404.104">{{$join ", " ($lookup $metadata 'legalStatuses.REGISTERED.createdAtLocation.name') ($lookup $metadata 'legalStatuses.REGISTERED.createdAtLocation.district') ($lookup $metadata 'legalStatuses.REGISTERED.createdAtLocation.province') ($lookup $metadata 'legalStatuses.REGISTERED.createdAtLocation.country')}}</tspan>
     </text>
   </g>
   <line x1="70" y1="410.5" x2="514" y2="410.5" stroke="#ECECEC" />

--- a/src/api/certificates/source/v2.death-certificate.svg
+++ b/src/api/certificates/source/v2.death-certificate.svg
@@ -128,8 +128,7 @@
           <tspan x="289.95" y="403.643">{{$join ", " ($lookup $declaration 'eventDetails.deathLocation.district') ($lookup $declaration 'eventDetails.deathLocation.province') ($lookup $declaration 'eventDetails.deathLocation.country')}}</tspan>
         {{else}}
           {{#ifCond ($lookup $declaration 'eventDetails.deathLocationOther') '!==' undefined }}
-          <tspan x="289.95" y="388.643">{{$or ($lookup $declaration 'eventDetails.deathLocationOther.district') ($lookup $declaration 'eventDetails.deathLocationOther.streetLevelDetails.district2')}}&#10;</tspan>
-          <tspan x="289.95" y="403.643">{{$join ", " ($or ($lookup $declaration 'eventDetails.deathLocationOther.streetLevelDetails.state') ($lookup $declaration 'eventDetails.deathLocationOther.province')) ($lookup $declaration 'eventDetails.deathLocationOther.country')}}</tspan>
+          <tspan x="289.95" y="388.643">{{$lookup $declaration 'eventDetails.deathLocationOther.administrativeHierarchy'}}</tspan>
           {{else}}
             {{#ifCond ($lookup $declaration 'deceased.address') '!==' undefined }}
             <tspan x="289.95" y="388.643">{{$or ($lookup $declaration 'deceased.address.district') ($lookup $declaration 'deceased.address.streetLevelDetails.district2')}}&#10;</tspan>


### PR DESCRIPTION
Fixes https://github.com/opencrvs/opencrvs-core/issues/12603

## Description

CC PR: https://github.com/opencrvs/opencrvs-countryconfig/pull/1423
Farajaland PR: https://github.com/opencrvs/opencrvs-farajaland/pull/2149

 Fixes missing village and incomplete location information in v2 birth and death certificate SVGs (issue #12603).

  **Root cause:** Certificate templates were using manual $join of district, province, country for address-type location fields, which omits village. Additionally, the `createdAtLocation.name` (registration office name) was missing from the Place of Registration field in certified copies.

  **Fix:**
  - Address fields (child.birthLocation.other, child.birthLocation.privateHome, eventDetails.deathLocationOther) now use administrativeHierarchy, which includes the full location hierarchy down to village level
  - createdAtLocation.name added to the Place of Registration join in `v2.birth-certificate-certified-copy.svg` and `v2.death-certificate-certified-copy.svg`
  - Facility/Location fields (child.birthLocation, eventDetails.deathLocation) are intentionally left with the district/province/country join — they are not address fields and do not carry village data

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
