### PR TITLE
fix:'National ID' field removed in advanced search for birth.

### DIFF
--- a/src/events/birth/advancedSearch.ts
+++ b/src/events/birth/advancedSearch.ts
@@ -79,10 +79,6 @@ export const advancedSearchBirth = [
         validations: [],
         conditionals: []
       }).fuzzy(),
-      field('child.nid', {
-        searchCriteriaLabelPrefix: childPrefix,
-        conditionals: []
-      }).exact(),
       field('child.gender', {
         searchCriteriaLabelPrefix: childPrefix
       }).exact()


### PR DESCRIPTION
## Description

removed the field from advanced Search of birth .

https://github.com/opencrvs/opencrvs-core/issues/12620

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
