### PR TITLE
fix(identity-fields): resolve duplicate idType rendering by splitting per nationality

### DIFF
--- a/src/events/utils/person.ts
+++ b/src/events/utils/person.ts
@@ -9,10 +9,27 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 
-import { and, ConditionalType, field, FieldConditional, FieldConfig, FieldConfigInput, FieldReference, FieldType, or, TranslationConfig, ValidationConfig } from '@opencrvs/toolkit/events'
+import {
+  and,
+  ConditionalType,
+  field,
+  FieldConditional,
+  FieldConfig,
+  FieldConfigInput,
+  FieldReference,
+  FieldType,
+  or,
+  TranslationConfig,
+  ValidationConfig
+} from '@opencrvs/toolkit/events'
 import { createSelectOptions } from '../utils'
 import { connectToMOSIPIdReader, getMOSIPIntegrationFields } from '../mosip'
-import { farajalandNameConfig, invalidNameValidator, nationalIdValidator, passportValidator } from '../birth/validators'
+import {
+  farajalandNameConfig,
+  invalidNameValidator,
+  nationalIdValidator,
+  passportValidator
+} from '../birth/validators'
 import { not } from '@opencrvs/toolkit/conditionals'
 
 export const IdType = {
@@ -72,21 +89,19 @@ export const yesNoRadioOptions = createSelectOptions(
   yesNoMessageDescriptors
 )
 
-export const getIdentityFields = (
-  {
-    prefix,
-    showConditional,
-    parent,
-    uniqueNidAgainst = [],
-    dobValidation = []
-  }:
-    {
-      prefix: string,
-      showConditional: any,
-      parent?: FieldReference,
-      uniqueNidAgainst?: string[],
-      dobValidation?: ValidationConfig[]
-    }): FieldConfigInput[] => {
+export const getIdentityFields = ({
+  prefix,
+  showConditional,
+  parent,
+  uniqueNidAgainst = [],
+  dobValidation = []
+}: {
+  prefix: string
+  showConditional: any
+  parent?: FieldReference
+  uniqueNidAgainst?: string[]
+  dobValidation?: ValidationConfig[]
+}): FieldConfigInput[] => {
   const conditionals = [
     {
       type: ConditionalType.SHOW,
@@ -109,7 +124,7 @@ export const getIdentityFields = (
       parent
     },
     {
-      id: `${prefix}.idType`,
+      id: `${prefix}.idTypeLocal`,
       type: FieldType.SELECT,
       required: true,
       label: {
@@ -121,7 +136,8 @@ export const getIdentityFields = (
       conditionals: [
         {
           type: ConditionalType.SHOW,
-          conditional: and(showConditional,
+          conditional: and(
+            showConditional,
             field(`${prefix}.nationality`).isEqualTo('FAR')
           )
         },
@@ -137,7 +153,7 @@ export const getIdentityFields = (
       parent
     },
     {
-      id: `${prefix}.idType`,
+      id: `${prefix}.idTypeForeigner`,
       type: FieldType.SELECT,
       required: true,
       label: {
@@ -149,12 +165,32 @@ export const getIdentityFields = (
       conditionals: [
         {
           type: ConditionalType.SHOW,
-          conditional: and(showConditional,
+          conditional: and(
+            showConditional,
             not(field(`${prefix}.nationality`).isEqualTo('FAR'))
           )
         }
       ],
       parent
+    },
+    {
+      id: `${prefix}.idType`,
+      type: FieldType.ALPHA_HIDDEN,
+      required: false,
+      label: {
+        defaultMessage: 'Form of ID meh',
+        description: 'This is the label for the field',
+        id: 'event.death.action.declare.form.section.informant.field.idType.label'
+      },
+      parent: [
+        ...(parent ? [parent] : []),
+        field(`${prefix}.idTypeLocal`),
+        field(`${prefix}.idTypeForeigner`)
+      ],
+      value: [
+        field(`${prefix}.idTypeLocal`),
+        field(`${prefix}.idTypeForeigner`)
+      ]
     },
     // fields:
     // ${prefix}.verified, ${prefix}.query-params, ${prefix}.verify-nid-http-fetch,
@@ -171,7 +207,6 @@ export const getIdentityFields = (
                 field(`${prefix}.idType`).isEqualTo(IdType.NATIONAL_ID),
                 field(`${prefix}.idType`).isEqualTo(IdType.PASSPORT)
               )
-
             )
           }
         ],
@@ -181,8 +216,7 @@ export const getIdentityFields = (
             conditional: and(
               showConditional,
               field(`${prefix}.nationality`).isEqualTo('FAR'),
-              field(`${prefix}.idType`).isEqualTo(IdType.NATIONAL_ID),
-
+              field(`${prefix}.idType`).isEqualTo(IdType.NATIONAL_ID)
             )
           }
         ]
@@ -210,16 +244,23 @@ export const getIdentityFields = (
         ],
         validation: [
           nationalIdValidator(`${prefix}.nid`),
-          ...(uniqueNidAgainst.length > 0 ? [{
-            message: {
-              defaultMessage: 'National id must be unique',
-              description: 'This is the error message for non-unique ID Number',
-              id: 'event.death.action.declare.form.nid.unique'
-            },
-            validator: and(
-              ...uniqueNidAgainst.map((otherId) => not(field(`${prefix}.nid`).isEqualTo(field(otherId))))
-            )
-          }] : [])
+          ...(uniqueNidAgainst.length > 0
+            ? [
+                {
+                  message: {
+                    defaultMessage: 'National id must be unique',
+                    description:
+                      'This is the error message for non-unique ID Number',
+                    id: 'event.death.action.declare.form.nid.unique'
+                  },
+                  validator: and(
+                    ...uniqueNidAgainst.map((otherId) =>
+                      not(field(`${prefix}.nid`).isEqualTo(field(otherId)))
+                    )
+                  )
+                }
+              ]
+            : [])
         ],
         parent
       },
@@ -248,9 +289,7 @@ export const getIdentityFields = (
             )
           }
         ],
-        validation: [
-          passportValidator(`${prefix}.passport`)
-        ],
+        validation: [passportValidator(`${prefix}.passport`)],
         parent
       },
       {
@@ -267,7 +306,7 @@ export const getIdentityFields = (
         required: true,
         hideLabel: true,
         label: {
-          defaultMessage: "Full name",
+          defaultMessage: 'Full name',
           description: 'This is the label for the field',
           id: `event.birth.action.declare.form.section.${prefix}.field.name.label`
         },
@@ -308,6 +347,6 @@ export const getIdentityFields = (
         valuePath: 'data.birthDate',
         disableIf: ['pending', 'verified', 'authenticated']
       }
-    ),
+    )
   ]
 }


### PR DESCRIPTION
## Description

https://github.com/opencrvs/opencrvs-core/issues/12635

The local and foreigner "Form of ID" SELECT fields both used the same `${prefix}.idType` id. Even though they are mutually exclusive via SHOW conditionals on nationality, having two fields registered under the same id caused rendering issues — React/form state treated them as the same node, so switching nationality did not cleanly swap which select was shown, and the value bound to `idType` could end up stale or tied to the wrong variant.  

Rename the two selects to `${prefix}.idTypeLocal` and `${prefix}.idTypeForeigner` so each has a unique id and its own independent state. Reintroduce `${prefix}.idType` as a hidden `ALPHA_HIDDEN` aggregator whose value mirrors whichever select is active, preserving every downstream conditional (MOSIP integration, NID/passport visibility, validators) that already reads from `${prefix}.idType`.  The hidden field's `parent` combines the optional `parent` prop with the two new selects; spread it conditionally so the array type stays `FieldReference[]` instead of `(FieldReference | undefined)[]`.  

Also reformat imports, the function signature, and validation arrays for consistency.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
