### PR TITLE
fix: Record does not go to the "Pending external validation"

### DIFF
--- a/src/api/registration/index.ts
+++ b/src/api/registration/index.ts
@@ -26,7 +26,8 @@ import {
   shouldForwardBirthRegistrationToMosip,
   shouldForwardDeathRegistrationToMosip,
   getBirthInformantSection,
-  getInformantPsut
+  getInformantPsut,
+  shouldForwardToExternalValidation
 } from '@countryconfig/events/mosip'
 import { InformantType as DeathInformantType } from '@countryconfig/events/death/forms/pages/informant'
 
@@ -163,6 +164,9 @@ export async function onMosipBirthRegisterHandler(
 
   const registrationNumber = generateRegistrationNumber()
 
+  if (shouldForwardToExternalValidation(declaration)) {
+    return h.response().code(202)
+  }
   if (!shouldForwardBirthRegistrationToMosip(declaration)) {
     logger.info(
       'Birth registration will not be forwarded to MOSIP based on custom logic.'

--- a/src/events/birth/index.ts
+++ b/src/events/birth/index.ts
@@ -518,6 +518,12 @@ export const birthEvent = defineConfig({
                 id: 'form.field.label.app.whoContDet.mother',
                 description: 'Label for mother'
               },
+              conditionals: [
+                {
+                  type: ConditionalType.SHOW,
+                  conditional: field('mother.detailsNotAvailable').isFalsy()
+                }
+              ],
               value: 'MOTHER'
             },
             {
@@ -526,12 +532,18 @@ export const birthEvent = defineConfig({
                 id: 'form.field.label.informantRelation.father',
                 description: 'Label for father'
               },
+              conditionals: [
+                {
+                  type: ConditionalType.SHOW,
+                  conditional: field('father.detailsNotAvailable').isFalsy()
+                }
+              ],
               value: 'FATHER'
             },
             {
               label: {
                 defaultMessage: 'Someone else',
-                id: 'form.field.label.informantRelation.others',
+                id: 'form.field.label.collector.others',
                 description: 'Label for someone else'
               },
               value: 'SOMEONE_ELSE'

--- a/src/events/mosip.ts
+++ b/src/events/mosip.ts
@@ -426,3 +426,22 @@ export function shouldForwardDeathRegistrationToMosip(
     declaration['informant.verified'] === 'authenticated'
   )
 }
+
+/**
+ * When a birth declaration is submitted where the child has no father or mother
+ * details available and only informant information is provided, and the
+ * informant's identity has been authenticated via e-Signet — the record should be
+ * forwarded to the external validation workqueue.
+ * Reference: https://github.com/opencrvs/opencrvs-core/issues/12731
+ * @param declaration The declaration object containing event data.
+ * @returns True if the registration should be forwarded to external validation, false otherwise.
+ */
+export function shouldForwardToExternalValidation(
+  declaration: Record<string, any>
+): boolean {
+  return (
+    declaration['mother.detailsNotAvailable'] &&
+    declaration['father.detailsNotAvailable'] &&
+    declaration['informant.verified'] === 'authenticated'
+  )
+}

--- a/src/translations/client.csv
+++ b/src/translations/client.csv
@@ -2321,3 +2321,4 @@ event.birth.action.declare.form.section.documents.field.acquiredChildCourtDocume
 event.birth.action.declare.form.review.print.label,Label for the print button in the review section,Print certificate inadvance of registration,Imprimer le certificat avant l'enregistrement
 form.field.label.informantRelation.self,Label for option self,Self,Soi-même
 event.birth.id-reader.helper-text,Helper text,"Authentication isn't required to register. To issue a UIN for the child, at least one parent must be authenticated","L'authentification n'est pas requise pour l'enregistrement. Pour délivrer un UIN à l'enfant, au moins un parent doit être authentifié"
+form.field.label.collector.others,Label for someone else,Someone else,Quelqu'un d'autre


### PR DESCRIPTION
Bug: Record does not go to the "Pending external validation" workqueue for a birth declaration when only informant identity is authenticated via e-Signet and no parent details are available

Fixes: 
 - https://github.com/opencrvs/opencrvs-core/issues/12731
 - https://github.com/opencrvs/opencrvs-core/issues/11830
## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
