### PR TITLE
Dont show archived records on 'Pending updates' workqueue

### DIFF
--- a/src/api/workqueue/workqueueConfig.ts
+++ b/src/api/workqueue/workqueueConfig.ts
@@ -147,6 +147,7 @@ export const Workqueues = defineWorkqueues([
       status: {
         type: 'anyOf',
         terms: [
+          EventStatus.enum.CREATED,
           EventStatus.enum.DECLARED,
           EventStatus.enum.NOTIFIED,
           EventStatus.enum.REGISTERED

--- a/src/api/workqueue/workqueueConfig.ts
+++ b/src/api/workqueue/workqueueConfig.ts
@@ -143,7 +143,15 @@ export const Workqueues = defineWorkqueues([
     },
     query: {
       ...createdInMyAdminArea,
-      flags: { anyOf: [InherentFlags.REJECTED] }
+      flags: { anyOf: [InherentFlags.REJECTED] },
+      status: {
+        type: 'anyOf',
+        terms: [
+          EventStatus.enum.DECLARED,
+          EventStatus.enum.NOTIFIED,
+          EventStatus.enum.REGISTERED
+        ]
+      }
     },
     action: { type: ActionType.READ }
   },


### PR DESCRIPTION
## Description

For now, I decided to keep the flags on archived records untouched. Later on we probably want to add in logic where archival 'hides' the flags (and returns them if unarchived), but not for v2.0.

So for now, simply fixing the workqueue config is sufficient.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
