### PR TITLE
fix: amend death certs to show address correctly

### DIFF
--- a/src/api/certificates/source/v2.death-certificate-certified-copy.svg
+++ b/src/api/certificates/source/v2.death-certificate-certified-copy.svg
@@ -84,11 +84,7 @@
   </text>
   <g clip-path="url(#clip2_948_2918)">
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px">
-      {{#ifCond ($lookup $declaration "deceased.address.addressType") '===' "INTERNATIONAL" }}
-        <tspan x="312" y="188.104">{{$join ", " ($lookup $declaration 'deceased.address.streetLevelDetails.district2') ($lookup $declaration 'deceased.address.streetLevelDetails.state') ($lookup $declaration 'deceased.address.country')}}</tspan>
-      {{else}}
-        <tspan x="312" y="188.104">{{$join ", " ($lookup $declaration 'deceased.address.district') ($lookup $declaration 'deceased.address.province') ($lookup $declaration 'deceased.address.country')}}</tspan>
-      {{/ifCond}}
+      <tspan x="312" y="188.104">{{$lookup $declaration 'deceased.address.administrativeHierarchy'}}</tspan>
     </text>
   </g>
   <line x1="70" y1="194.5" x2="514" y2="194.5" stroke="#ECECEC" />
@@ -143,18 +139,17 @@
   <g clip-path="url(#clip6_948_2918)">
     <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px">
       {{#ifCond ($lookup $declaration "eventDetails.deathLocation") '!==' undefined }}
-          <tspan x="312" y="294.104">{{$lookup $declaration "eventDetails.deathLocation.name"}}&#10;</tspan>
-          <tspan x="312" y="306.104">{{$join ", " ($lookup $declaration 'eventDetails.deathLocation.district') ($lookup $declaration 'eventDetails.deathLocation.province') ($lookup $declaration 'eventDetails.deathLocation.country')}}</tspan>
-        {{else}}
-          {{#ifCond ($lookup $declaration 'eventDetails.deathLocationOther') '!==' undefined }}
+        <tspan x="312" y="294.104">{{$lookup $declaration "eventDetails.deathLocation.name"}},&#10;</tspan>
+        <tspan x="312" y="306.104">{{$join ", " ($lookup $declaration 'eventDetails.deathLocation.district') ($lookup $declaration 'eventDetails.deathLocation.province') ($lookup $declaration 'eventDetails.deathLocation.country')}}</tspan>
+      {{else}}
+        {{#ifCond ($lookup $declaration 'eventDetails.deathLocationOther') '!==' undefined }}
           <tspan x="312" y="294.104">{{$lookup $declaration 'eventDetails.deathLocationOther.administrativeHierarchy'}}</tspan>
-          {{else}}
-            {{#ifCond ($lookup $declaration 'deceased.address') '!==' undefined }}
-            <tspan x="312" y="294.104">{{$or ($lookup $declaration 'deceased.address.district') ($lookup $declaration 'deceased.address.streetLevelDetails.district2')}}&#10;</tspan>
-            <tspan x="312" y="306.104">{{$join ", " ($or ($lookup $declaration 'deceased.address.streetLevelDetails.state') ($lookup $declaration 'deceased.address.province')) ($lookup $declaration 'deceased.address.country')}}</tspan>
-            {{/ifCond}}
+        {{else}}
+          {{#ifCond ($lookup $declaration 'eventDetails.deathLocationResidential') '!==' undefined }}
+            <tspan x="312" y="294.104">{{$lookup $declaration 'eventDetails.deathLocationResidential.administrativeHierarchy'}}</tspan>
           {{/ifCond}}
         {{/ifCond}}
+      {{/ifCond}}
     </text>
   </g>
   <line x1="70" y1="312.5" x2="514" y2="312.5" stroke="#ECECEC" />

--- a/src/api/certificates/source/v2.death-certificate.svg
+++ b/src/api/certificates/source/v2.death-certificate.svg
@@ -130,9 +130,8 @@
           {{#ifCond ($lookup $declaration 'eventDetails.deathLocationOther') '!==' undefined }}
           <tspan x="289.95" y="388.643">{{$lookup $declaration 'eventDetails.deathLocationOther.administrativeHierarchy'}}</tspan>
           {{else}}
-            {{#ifCond ($lookup $declaration 'deceased.address') '!==' undefined }}
-            <tspan x="289.95" y="388.643">{{$or ($lookup $declaration 'deceased.address.district') ($lookup $declaration 'deceased.address.streetLevelDetails.district2')}}&#10;</tspan>
-            <tspan x="289.95" y="403.643">{{$join ", " ($or ($lookup $declaration 'deceased.address.streetLevelDetails.state') ($lookup $declaration 'deceased.address.province')) ($lookup $declaration 'deceased.address.country')}}</tspan>
+            {{#ifCond ($lookup $declaration 'eventDetails.deathLocationResidential') '!==' undefined }}
+            <tspan x="289.95" y="388.643">{{$lookup $declaration 'eventDetails.deathLocationResidential.administrativeHierarchy'}}</tspan>
             {{/ifCond}}
           {{/ifCond}}
         {{/ifCond}}


### PR DESCRIPTION
## Description

Fixes [missing location](https://github.com/opencrvs/opencrvs-core/issues/12603#issuecomment-4648939579) data in v2 death certificate SVGs (follows up on #5, related to opencrvs/opencrvs-core#12603).

- `deathLocationResidential` was missing entirely — the "Residential Address" place of death option never appeared on the certificate. Added it as the third case after `deathLocation` (facility) and `deathLocationOther`.
- `deceased.address` was incorrectly used as a fallback for place of death. Removed.
- `deceased.address` (Resident at field) now uses `administrativeHierarchy` to include village.
- `deathLocationOther` also switched to `administrativeHierarchy`.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly