### PR TITLE
fix(death): add validated flag on declare for EMBASSY_OFFICIALs

### DIFF
--- a/src/events/death/index.ts
+++ b/src/events/death/index.ts
@@ -241,7 +241,8 @@ export const deathEvent = defineConfig({
           operation: 'add',
           conditional: or(
             user.hasRole('REGISTRATION_AGENT'),
-            user.hasRole('LOCAL_REGISTRAR')
+            user.hasRole('LOCAL_REGISTRAR'),
+            user.hasRole('EMBASSY_OFFICIAL')
           )
         }
       ]


### PR DESCRIPTION
records declared by EMBASSY_OFFICIALs should get the "validated" flag included automatically. Was already done for birth, missing in death
<img width="1920" height="1080" alt="ocrvs-12874" src="https://github.com/user-attachments/assets/34f4c9cf-c8b1-43df-95ab-4d5348bfec72" />
