### PR TITLE
[OCRVS-12856] Fix wrong fonts causing clipping issues

### DIFF
--- a/src/api/certificates/handler.ts
+++ b/src/api/certificates/handler.ts
@@ -255,7 +255,7 @@ export async function certificateHandler(
       },
       svgUrl:
         '/api/countryconfig/certificates/v2.birth-certificate-certified-copy.svg',
-      fonts: libreBaskervilleFont,
+      fonts: notoSansFont,
       conditionals: [
         {
           type: 'SHOW',
@@ -283,7 +283,7 @@ export async function certificateHandler(
         delayed: 18
       },
       svgUrl: '/api/countryconfig/certificates/v2.death-certificate.svg',
-      fonts: libreBaskervilleFont
+      fonts: notoSansFont
     },
     {
       id: 'v2.death-certified-certificate',
@@ -302,7 +302,7 @@ export async function certificateHandler(
       },
       svgUrl:
         '/api/countryconfig/certificates/v2.death-certificate-certified-copy.svg',
-      fonts: libreBaskervilleFont
+      fonts: { ...notoSansFont, ...libreBaskervilleFont }
     }
   ]
   return certificateConfigs


### PR DESCRIPTION
## Why

Three v2 certificate templates had `libreBaskervilleFont` registered as their pdfmake font, despite their SVGs using `font-family="Noto Sans"` for all body text. pdfmake only resolves fonts from its explicit registry — any unregistered family silently falls back to the default (the first registered font). As a result, the entire certificate body rendered in Libre Baskerville (serif) in the printed PDF, while the on-screen preview correctly showed Noto Sans (sans-serif). Because Libre Baskerville has wider glyph metrics than Noto Sans, text overflowed the SVG `clip-path` boxes that were sized for Noto Sans — causing field values and headers to be visibly clipped in the PDF. The mismatch also made the PDF look completely different from the preview.

## What changes

### `opencrvs-demoland` — `handler.ts`

| Template | Before | After |
|---|---|---|
| `v2.birth-certified-certificate` | `libreBaskervilleFont` | `notoSansFont` |
| `v2.death-certificate` | `libreBaskervilleFont` | `notoSansFont` |
| `v2.death-certified-certificate` | `libreBaskervilleFont` | `{ ...notoSansFont, ...libreBaskervilleFont }` |

The death certified copy registers both fonts because its SVG uses Libre Baskerville for the NID field alongside Noto Sans for all other body text.

## How to test

1. Log in as a registrar on a v2 deployment (Farajaland demo staging).
2. Navigate to **Print Certificate** on any registered death or birth event.
3. On the review page, note the on-screen preview renders in Noto Sans (sans-serif).
4. Click **"Yes, print certificate"** and open the generated PDF:
   - Body text (field labels and values) must appear in **Noto Sans** (sans-serif), matching the preview — not Libre Baskerville (serif).
   - The NID field on the death certified copy should render in Libre Baskerville.
5. Repeat for **Birth Certificate certified copy** and **Death Certificate**.

### Output PDF 

[correct-fonts.pdf](https://github.com/user-attachments/files/28835542/correct-fonts.pdf)
