### PR TITLE
fix: numbering on birth-certified-copy

### DIFF
--- a/src/api/certificates/source/v2.birth-certificate-certified-copy.svg
+++ b/src/api/certificates/source/v2.birth-certificate-certified-copy.svg
@@ -276,7 +276,7 @@
   </text>
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="bold" letter-spacing="0px">
-    <tspan x="65" y="392.104">10.</tspan>
+    <tspan x="65" y="392.104">9.</tspan>
   </text>
   <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="600" letter-spacing="0px">
@@ -291,7 +291,7 @@
   <line x1="65" y1="398.5" x2="533" y2="398.5" stroke="#ECECEC" />
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="bold" letter-spacing="0px">
-    <tspan x="65" y="412.104">11.</tspan>
+    <tspan x="65" y="412.104">10.</tspan>
   </text>
   <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="600" letter-spacing="0px">
@@ -310,7 +310,7 @@
   <line x1="65" y1="418.5" x2="533" y2="418.5" stroke="#ECECEC" />
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="bold" letter-spacing="0px">
-    <tspan x="65" y="432.104">12.</tspan>
+    <tspan x="65" y="432.104">11.</tspan>
   </text>
   <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="600" letter-spacing="0px">
@@ -331,7 +331,7 @@
   <line x1="65" y1="438.5" x2="533" y2="438.5" stroke="#ECECEC" />
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="bold" letter-spacing="0px">
-    <tspan x="65" y="452.104">13.</tspan>
+    <tspan x="65" y="452.104">12.</tspan>
   </text>
   <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="600" letter-spacing="0px">
@@ -365,7 +365,7 @@
   </text>
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="bold" letter-spacing="0px">
-    <tspan x="65" y="518.104">15.</tspan>
+    <tspan x="65" y="518.104">13.</tspan>
   </text>
   <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="600" letter-spacing="0px">
@@ -391,7 +391,7 @@
   <line x1="65" y1="536.5" x2="533" y2="536.5" stroke="#ECECEC" />
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="bold" letter-spacing="0px">
-    <tspan x="65" y="550.104">16.</tspan>
+    <tspan x="65" y="550.104">14.</tspan>
   </text>
   <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="600" letter-spacing="0px">
@@ -407,7 +407,7 @@
   <line x1="65" y1="556.5" x2="533" y2="556.5" stroke="#ECECEC" />
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="bold" letter-spacing="0px">
-    <tspan x="65" y="570.104">17.</tspan>
+    <tspan x="65" y="570.104">15.</tspan>
   </text>
   <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="600" letter-spacing="0px">
@@ -422,7 +422,7 @@
   <line x1="65" y1="576.5" x2="533" y2="576.5" stroke="#ECECEC" />
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="bold" letter-spacing="0px">
-    <tspan x="65" y="590.104">18.</tspan>
+    <tspan x="65" y="590.104">16.</tspan>
   </text>
   <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
     font-size="8" font-weight="600" letter-spacing="0px">


### PR DESCRIPTION
## Description

Before:
<img width="1098" height="1492" alt="image" src="https://github.com/user-attachments/assets/8eb38c16-c87a-4c78-85d9-68fc8fb17cdb" />



After:
<img width="246" height="493" alt="image" src="https://github.com/user-attachments/assets/49c45df7-32b9-449b-970e-6da93359c95d" />


Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
