### PR TITLE
fix: update svgs to use latest handlebars for signatures

### DIFF
--- a/src/api/certificates/source/v2.birth-certificate-certified-copy.svg
+++ b/src/api/certificates/source/v2.birth-certificate-certified-copy.svg
@@ -530,5 +530,5 @@
   </defs>
   <image x="506.287" y="784" width="34.7131" height="35" xlink:href="{{qrCode}}" />
   <image id="image0_946_2501" x="331.453" y="670" width="194.513" height="68"
-    xlink:href="{{$lookup $metadata 'assignedTo.signature'}}" />
+    xlink:href="{{$lookup ($action 'ASSIGN') 'createdBySignature'}}" />
 </svg>

--- a/src/api/certificates/source/v2.birth-certificate.svg
+++ b/src/api/certificates/source/v2.birth-certificate.svg
@@ -414,7 +414,7 @@
 
   <!-- #ifCond printInAdvance '!==' true}} -->
   <image width="140" height="70"
-    xlink:href="{{$lookup $metadata 'legalStatuses.REGISTERED.createdBySignature'}}"
+    xlink:href="{{$lookup ($action 'REGISTER') 'createdBySignature'}}"
     x="
   347" y=" 644"></image>
   <!-- /ifCond}} -->

--- a/src/api/certificates/source/v2.death-certificate-certified-copy.svg
+++ b/src/api/certificates/source/v2.death-certificate-certified-copy.svg
@@ -316,5 +316,5 @@
     </clipPath>
   </defs>
   <image id="image2_948_2918" x="498.287" y="784" width="34.7131" height="35" xlink:href="{{qrCode}}" />
-  <image id="image0_948_2918" x="323.826" y="669" width="182.139" height="68" xlink:href="{{$lookup $metadata 'legalStatuses.REGISTERED.createdBySignature'}}" />
+  <image id="image0_948_2918" x="323.826" y="669" width="182.139" height="68" xlink:href="{{$lookup ($action 'REGISTER') 'createdBySignature'}}" />
 </svg>

--- a/src/api/certificates/source/v2.death-certificate.svg
+++ b/src/api/certificates/source/v2.death-certificate.svg
@@ -283,5 +283,5 @@
     </clipPath>
   </defs>
   <image width="36" height="36" xlink:href="{{qrCode}}" x="500" y="770"></image>
-  <image width="140" height="70" xlink:href="{{$lookup $metadata 'legalStatuses.REGISTERED.createdBySignature'}}" x="347" y="605"></image>
+  <image width="140" height="70" xlink:href="{{$lookup ($action 'REGISTER') 'createdBySignature'}}" x="347" y="605"></image>
 </svg>


### PR DESCRIPTION
## Description

Fixes https://github.com/opencrvs/opencrvs-core/issues/12802#issuecomment-4705998620

Update svgs to use remove the deprecated handlebars (`{{$lookup $metadata 'legalStatuses.REGISTERED.createdBySignature'}}`) and use new ones (`{{$lookup ($action 'REGISTER') 'createdBySignature'}}"`). 

https://github.com/opencrvs/opencrvs-core/pull/12616#issue-4435954534

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
