### PR TITLE
[OCRVS-12856] Fix: reduce MAX_NAME_LENGTH to 13 to prevent certificate overflow

### DIFF
--- a/src/events/birth/validators.ts
+++ b/src/events/birth/validators.ts
@@ -11,7 +11,11 @@
 import { and, or, field } from '@opencrvs/toolkit/events'
 import { defineFormConditional, not } from '@opencrvs/toolkit/conditionals'
 
-export const MAX_NAME_LENGTH = 32
+// Derived from the tightest SVG certificate clip area (202px, 8px Noto Sans).
+// Worst-case character: W ≈ 6.9px → 2N × 6.9 + 2 (space) ≤ 202 → N ≤ 14.
+// Set to 13 for an additional safety margin (~181px used of 202px available).
+// Increase only if all certificate clip paths are widened accordingly.
+export const MAX_NAME_LENGTH = 13
 
 export const invalidNameValidator = (fieldName: string) => ({
   message: {


### PR DESCRIPTION
Possible fix for https://github.com/opencrvs/opencrvs-core/issues/12856

## Why

Long names in `deceased.name.fullname` and `informant.name.fullname` (and equivalent fields across birth and marriage events) overflow the SVG clip area in printed certificates. The tightest clip is 202px wide at 8px Noto Sans. With the previous limit of 32 characters per name part, a worst-case fullname (`32 + 1 space + 32 = 65 chars`) could render at ~293px — nearly 100px over the boundary. This is visible as names being cut off on the printed certificate.

## What changes

- `src/events/birth/validators.ts`: reduced `MAX_NAME_LENGTH` from `32` to `13`
  - Applies to all name fields across birth, death, and marriage events (deceased, informant, child, mother, father, spouse, collector) via the shared `farajalandNameConfig`
  - Added a derivation comment explaining the SVG clip geometry constraint so the value is not accidentally increased in future (`W ≈ 6.9px → 2N × 6.9 + 2 ≤ 202 → N ≤ 14; set to 13 for ~181px worst-case`)

## How to test

1. Open a death registration form and attempt to enter more than 13 characters in the deceased first name or surname field — input should be capped at 13.
2. Complete a death registration with a name at the 13-char limit (e.g. `Bartholomew` / `Bartholomew`) and print the certified copy — the name must fit within the certificate without overflow.
3. Stress test: enter 13 × `W` for both firstname and surname (worst-case ~181px, within the 202px clip) and verify the printed certificate renders correctly.
4. Repeat steps 1–3 on birth and marriage registration forms to confirm the limit applies consistently across all events.


## Example of a certificate with fixes
<img width="1620" height="2339" alt="death-certified-copy-fixed-1" src="https://github.com/user-attachments/assets/fe3f3dd8-a5c1-474c-864d-b77bac119b13" />
 
  