### PR TITLE
Fix 'Place of certification', signature and names on death certificates

### DIFF
--- a/src/api/certificates/source/v2.death-certificate-certified-copy.svg
+++ b/src/api/certificates/source/v2.death-certificate-certified-copy.svg
@@ -34,7 +34,7 @@
    {{/ifCond}}
   <path d="M316.793 740L512.999 740.925" stroke="#CCCCCC" stroke-width="0.782258" stroke-dasharray="3.13 1.56" />
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px">
-    <tspan x="373.248" y="753.656">Registrar: {{ $lookup $metadata "updatedBy.name"}}</tspan>
+    <tspan x="373.248" y="753.656">Certified by: {{ $lookup $metadata "updatedBy.name"}}</tspan>
   </text>
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px">
     <tspan x="69" y="623.604">I certify that this certificate is a true copy of the civil registry and is issued by the mandated authority in</tspan>
@@ -316,5 +316,5 @@
     </clipPath>
   </defs>
   <image id="image2_948_2918" x="498.287" y="784" width="34.7131" height="35" xlink:href="{{qrCode}}" />
-  <image id="image0_948_2918" x="323.826" y="669" width="182.139" height="68" xlink:href="{{$lookup ($action 'REGISTER') 'createdBySignature'}}" />
+  <image id="image0_948_2918" x="323.826" y="669" width="182.139" height="68" xlink:href="{{$lookup ($action 'ASSIGN') 'createdBySignature'}}" />
 </svg>

--- a/src/api/certificates/source/v2.death-certificate.svg
+++ b/src/api/certificates/source/v2.death-certificate.svg
@@ -17,8 +17,8 @@
   </text>
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px">
     <tspan x="240.727" y="647.312">&#x2028;</tspan>
-    <tspan x="81" y="660.112">{{$lookup $metadata 'createdAtLocation.name'}}</tspan>
-    <tspan x="81" y="672.912">{{$join ", " ($lookup $metadata 'createdAtLocation.district') ($lookup $metadata 'createdAtLocation.province') ($lookup $metadata 'createdAtLocation.country')}}</tspan>
+    <tspan x="81" y="660.112">{{$lookup $metadata 'updatedAtLocation.name'}}</tspan>
+    <tspan x="81" y="672.912">{{$join ", " ($lookup $metadata 'updatedAtLocation.district') ($lookup $metadata 'updatedAtLocation.province') ($lookup $metadata 'updatedAtLocation.country')}}</tspan>
   </text>
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" font-weight="600" letter-spacing="0px">
     <tspan x="81" y="647.312">Place of certification / Lieu de certification</tspan>

--- a/src/api/certificates/source/v2.death-certificate.svg
+++ b/src/api/certificates/source/v2.death-certificate.svg
@@ -28,7 +28,7 @@
     <tspan x="357.752" y="687.343">Registrar / L&#39;Officier de l&#39;&#xc9;tat Civil</tspan>
   </text>
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="7.76" letter-spacing="0px">
-    <tspan x="398.064" y="699.954">{{ $lookup $metadata "updatedBy.name"}}</tspan>
+    <tspan x="398.064" y="699.954">{{ $lookup $metadata "legalStatuses.REGISTERED.createdBy.name"}}</tspan>
   </text>
   <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px">
     <tspan x="81.3999" y="563.615">I certify that this certificate is a true copy of the civil registry and is issued by the mandated authority in pursuance </tspan>


### PR DESCRIPTION
## Description

Resolves https://github.com/opencrvs/opencrvs-core/issues/12982
And https://github.com/opencrvs/opencrvs-core/issues/12984

Fixed:
<img width="676" height="800" alt="Screenshot 2026-06-17 at 18 58 11" src="https://github.com/user-attachments/assets/fe18d258-e65d-4f0d-a49a-562d4f2c110e" />


## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
